### PR TITLE
fix(datamesh): preserve ISO8601-2 negative periods in timefilter

### DIFF
--- a/packages/datamesh/package.json
+++ b/packages/datamesh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oceanum/datamesh",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "scripts": {
     "build": "vite build",
     "build:docs": "typedoc"

--- a/packages/datamesh/src/lib/query.ts
+++ b/packages/datamesh/src/lib/query.ts
@@ -70,6 +70,17 @@ export type LevelFilter = {
 
 /**
  * TimeFilter type representing a temporal subset or interpolation.
+ *
+ * Each entry in `times` may be an absolute time (a `Date`, a dayjs object or an
+ * ISO8601 datetime string) or a period relative to the current time (a dayjs
+ * duration or an ISO8601 duration string such as `"P7D"`).
+ *
+ * Periods follow the ISO8601-2 convention where a leading minus sign denotes a
+ * negative period. A period is resolved relative to the current time: a
+ * positive period (e.g. `"P7D"`) resolves to a time *after* now, while a
+ * negative period (e.g. `"-P7D"`) resolves to a time *before* now. This applies
+ * equally to the start and end of a range, so e.g. `times: ["-P7D", "P1D"]`
+ * selects from 7 days before now to 1 day after now.
  */
 export type TimeFilter = {
   type?: TimeFilterType;
@@ -78,22 +89,35 @@ export type TimeFilter = {
   resample?: ResampleType;
 };
 
+/**
+ * Convert a time or period value into the string used in the query payload.
+ *
+ * Absolute times become ISO8601 datetime strings; periods become ISO8601
+ * duration strings, preserving the ISO8601-2 sign so that negative periods
+ * (e.g. `"-P7D"`) are sent through unchanged rather than being coerced to
+ * positive ones.
+ */
 const stringifyTime = (
-  t: Date | dayjs.Dayjs | duration.Duration | string
+  t: Date | dayjs.Dayjs | duration.Duration | string,
 ): string => {
   if (t instanceof Date) {
-    return dayjs(t as Date).toISOString();
-  } else if (t instanceof dayjs) {
-    return (t as dayjs.Dayjs).toISOString();
-  } else if (t instanceof dayjs.duration) {
-    return (t as duration.Duration).toISOString();
-  } else {
-    try {
-      return dayjs.duration(t as string).toISOString();
-    } catch {
-      return dayjs(t as string).toISOString();
-    }
+    return dayjs(t).toISOString();
+  } else if (dayjs.isDayjs(t)) {
+    return t.toISOString();
+  } else if (dayjs.isDuration(t)) {
+    // Duration objects already encode the sign in toISOString().
+    return t.toISOString();
   }
+  const s = t as string;
+  // ISO8601 duration: optional ISO8601-2 sign followed by 'P...'.
+  const match = s.match(/^([+-])?P/);
+  if (match) {
+    // dayjs.duration() drops the leading sign when parsing a string, so strip
+    // and re-apply it to preserve negative periods.
+    const sign = match[1] === "-" ? "-" : "";
+    return sign + dayjs.duration(s.replace(/^[+-]/, "")).toISOString();
+  }
+  return dayjs(s).toISOString();
 };
 
 const timeFilterValidate = (timefilter: TimeFilter): TimeFilter => {

--- a/packages/datamesh/src/test/timefilter.test.ts
+++ b/packages/datamesh/src/test/timefilter.test.ts
@@ -1,0 +1,57 @@
+import { describe, test, expect } from "vitest";
+import dayjs from "dayjs";
+import duration from "dayjs/plugin/duration";
+import { Query } from "../lib/query";
+
+dayjs.extend(duration);
+
+const times = (timefilter: { times: (string | Date | object)[] }) =>
+  new Query({ datasource: "test", timefilter: timefilter as never }).timefilter
+    ?.times;
+
+describe("timefilter ISO8601 period handling", () => {
+  test("positive ISO8601 period strings resolve after now and are preserved", () => {
+    expect(times({ times: ["P7D", "P1D"] })).toEqual(["P7D", "P1D"]);
+  });
+
+  test("negative ISO8601 period strings (ISO8601-2) are preserved", () => {
+    // Negative => before now, positive => after now, for both tstart and tend.
+    expect(times({ times: ["-P7D", "P1D"] })).toEqual(["-P7D", "P1D"]);
+    expect(times({ times: ["-P7D", "-P1D"] })).toEqual(["-P7D", "-P1D"]);
+  });
+
+  test("negative period with a time component keeps its sign", () => {
+    expect(times({ times: ["-P1DT12H", "PT6H"] })).toEqual([
+      "-P1DT12H",
+      "PT6H",
+    ]);
+  });
+
+  test("dayjs duration objects preserve their sign", () => {
+    expect(
+      times({
+        times: [dayjs.duration(-7, "days"), dayjs.duration(2, "days")],
+      }),
+    ).toEqual(["-P7D", "P2D"]);
+  });
+
+  test("absolute Date values become ISO8601 datetimes", () => {
+    expect(times({ times: [new Date("2020-01-01T00:00:00Z")] })).toEqual([
+      "2020-01-01T00:00:00.000Z",
+    ]);
+  });
+
+  test("ISO8601 datetime strings are normalised, not treated as periods", () => {
+    expect(
+      times({ times: ["2020-01-01T00:00:00Z", "2020-01-02T00:00:00Z"] }),
+    ).toEqual(["2020-01-01T00:00:00.000Z", "2020-01-02T00:00:00.000Z"]);
+  });
+
+  test("type defaults to range", () => {
+    const q = new Query({
+      datasource: "test",
+      timefilter: { times: ["-P7D", "P1D"] },
+    });
+    expect(q.timefilter?.type).toBe("range");
+  });
+});


### PR DESCRIPTION
## Summary

Makes ISO8601 periods in the datamesh `timefilter` consistent with the ISO8601-2 convention, so negative periods like `-P7D` are handled correctly.

**Convention:** a period in a timefilter resolves relative to the current time — a positive period (e.g. `P7D`) resolves to a time *after* now, a negative period (e.g. `-P7D`) to a time *before* now. This applies equally to `tstart` and `tend`.

## The bug

- `dayjs.duration("-P7D")` silently **drops the leading sign** (→ `P7D`, `asDays()` → `7`), so a negative period passed through `stringifyTime` was coerced to positive.
- The `instanceof dayjs.duration` branch was **always `false`**, so duration objects fell through to the string path.

## Fix (`packages/datamesh/src/lib/query.ts`)

- `stringifyTime` now detects the ISO8601-2 sign on string periods, parses the unsigned remainder, and re-applies the sign so `-P7D` stays `-P7D`.
- Uses `dayjs.isDuration()` / `dayjs.isDayjs()` for robust type detection (duration objects already encode the sign in `toISOString()`).
- Documents the convention on the `TimeFilter` type and the helper.

## Tests

New `packages/datamesh/src/test/timefilter.test.ts` (7 cases via the public `Query` class): positive/negative string periods, periods with a time component, signed duration objects, absolute `Date`/datetime strings, and the default `range` type. All pass; lib + spec typecheck clean.

## Version

Bumps `@oceanum/datamesh` `0.8.4` → `0.8.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)