### PR TITLE
fix(datamesh): decode Arrow LargeUtf8/LargeBinary columns

### DIFF
--- a/packages/datamesh/package.json
+++ b/packages/datamesh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oceanum/datamesh",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "scripts": {
     "build": "vite build",
     "build:docs": "typedoc"

--- a/packages/datamesh/src/lib/datamodel.ts
+++ b/packages/datamesh/src/lib/datamodel.ts
@@ -208,9 +208,12 @@ const getDtype = (data: Data): DataType => {
 const arrowTypeToDType = (dtype: ArrowDataType): DataType => {
   //Convert arrow data type to zarr datatype
   let type: string = dtype.toString().toLowerCase();
-  if (dtype.typeId == 5) {
+  // Map string columns to the object dtype. LargeUtf8 must be handled alongside
+  // Utf8: pandas/polars pyarrow-backed strings serialize as Arrow large_string,
+  // which would otherwise fall through to an unrecognised "largeutf8" dtype.
+  if (ArrowDataType.isUtf8(dtype) || ArrowDataType.isLargeUtf8(dtype)) {
     type = "v2:object";
-  } else if (dtype.typeId == 1) {
+  } else if (ArrowDataType.isNull(dtype)) {
     type = "uint8";
   }
   return type as DataType;
@@ -767,7 +770,10 @@ export class Dataset<S extends HttpZarr | TempZarr> {
         array = carray;
         dtype = "float64";
         attrs = { unit: `Unix timestamp (s)` };
-      } else if (ArrowDataType.isBinary(field.type)) {
+      } else if (
+        ArrowDataType.isBinary(field.type) ||
+        ArrowDataType.isLargeBinary(field.type)
+      ) {
         const carray = [];
         for (let i = 0; i < array.length; i++) {
           carray.push(new Buffer(array[i]).toString("base64"));

--- a/packages/datamesh/src/lib/datamodel.ts
+++ b/packages/datamesh/src/lib/datamodel.ts
@@ -208,10 +208,21 @@ const getDtype = (data: Data): DataType => {
 const arrowTypeToDType = (dtype: ArrowDataType): DataType => {
   //Convert arrow data type to zarr datatype
   let type: string = dtype.toString().toLowerCase();
-  // Map string columns to the object dtype. LargeUtf8 must be handled alongside
-  // Utf8: pandas/polars pyarrow-backed strings serialize as Arrow large_string,
-  // which would otherwise fall through to an unrecognised "largeutf8" dtype.
-  if (ArrowDataType.isUtf8(dtype) || ArrowDataType.isLargeUtf8(dtype)) {
+  // Map string columns to the object dtype. Beyond plain Utf8 this must cover:
+  //  - LargeUtf8: pandas/polars pyarrow-backed strings serialize as large_string;
+  //  - Dictionary<_, Utf8 | LargeUtf8>: pandas `category` and polars
+  //    Categorical/Enum columns serialize dictionary-encoded.
+  // toArray() decodes all of these to plain strings, so they share one dtype;
+  // otherwise they fall through to an unrecognised dtype (e.g. "largeutf8").
+  const isStringDict =
+    ArrowDataType.isDictionary(dtype) &&
+    (ArrowDataType.isUtf8(dtype.dictionary) ||
+      ArrowDataType.isLargeUtf8(dtype.dictionary));
+  if (
+    ArrowDataType.isUtf8(dtype) ||
+    ArrowDataType.isLargeUtf8(dtype) ||
+    isStringDict
+  ) {
     type = "v2:object";
   } else if (ArrowDataType.isNull(dtype)) {
     type = "uint8";

--- a/packages/datamesh/src/test/large-arrow-types.test.ts
+++ b/packages/datamesh/src/test/large-arrow-types.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "vitest";
+import {
+  Table,
+  Vector,
+  makeData,
+  vectorFromArray,
+  Float64,
+  LargeUtf8,
+  LargeBinary,
+} from "apache-arrow";
+
+import { Dataset } from "../lib/datamodel";
+
+// Regression: Arrow LargeUtf8 / LargeBinary columns broke Dataset.fromArrow.
+// pandas/polars pyarrow-backed string columns serialize as `large_string`
+// (LargeUtf8, typeId 20) rather than `string` (Utf8, typeId 5); the dtype
+// mapper only special-cased Utf8, so a LargeUtf8 column produced an
+// unrecognised "largeutf8" dtype and threw
+// `Unknown or unsupported data_type: largeutf8`. LargeBinary (typeId 19) had
+// the matching gap in the binary base64 branch.
+
+const enc = new TextEncoder();
+
+const largeUtf8Vector = (strings: string[]): Vector => {
+  const bytes = strings.map((s) => enc.encode(s));
+  const total = bytes.reduce((n, b) => n + b.length, 0);
+  const data = new Uint8Array(total);
+  const valueOffsets = new BigInt64Array(strings.length + 1);
+  let offset = 0;
+  bytes.forEach((b, i) => {
+    data.set(b, offset);
+    offset += b.length;
+    valueOffsets[i + 1] = BigInt(offset);
+  });
+  return new Vector([
+    makeData({
+      type: new LargeUtf8(),
+      length: strings.length,
+      nullCount: 0,
+      valueOffsets,
+      data,
+    }),
+  ]);
+};
+
+const largeBinaryVector = (buffers: Uint8Array[]): Vector => {
+  const total = buffers.reduce((n, b) => n + b.length, 0);
+  const data = new Uint8Array(total);
+  const valueOffsets = new BigInt64Array(buffers.length + 1);
+  let offset = 0;
+  buffers.forEach((b, i) => {
+    data.set(b, offset);
+    offset += b.length;
+    valueOffsets[i + 1] = BigInt(offset);
+  });
+  return new Vector([
+    makeData({
+      type: new LargeBinary(),
+      length: buffers.length,
+      nullCount: 0,
+      valueOffsets,
+      data,
+    }),
+  ]);
+};
+
+describe("fromArrow with large Arrow types", () => {
+  test("decodes LargeUtf8 and LargeBinary columns", async () => {
+    const table = new Table({
+      name: largeUtf8Vector(["alpha", "beta", "gamma"]),
+      blob: largeBinaryVector([
+        Uint8Array.of(1, 2, 3),
+        Uint8Array.of(4, 5),
+        Uint8Array.of(6),
+      ]),
+      value: vectorFromArray([1.5, 2.5, 3.5], new Float64()),
+    });
+
+    const dataset = await Dataset.fromArrow(table, {});
+    const rows = await dataset.asDataframe();
+
+    expect(rows).toHaveLength(3);
+    // LargeUtf8 round-trips as plain strings.
+    expect(rows.map((r) => r.name)).toEqual(["alpha", "beta", "gamma"]);
+    // Numeric control column is unaffected.
+    expect(rows.map((r) => r.value)).toEqual([1.5, 2.5, 3.5]);
+    // LargeBinary is base64-encoded, exactly like Binary.
+    expect(rows[0].blob).toBe(Buffer.from([1, 2, 3]).toString("base64"));
+    expect(rows.map((r) => r.blob)).toEqual([
+      Buffer.from([1, 2, 3]).toString("base64"),
+      Buffer.from([4, 5]).toString("base64"),
+      Buffer.from([6]).toString("base64"),
+    ]);
+  });
+});

--- a/packages/datamesh/src/test/large-arrow-types.test.ts
+++ b/packages/datamesh/src/test/large-arrow-types.test.ts
@@ -4,21 +4,28 @@ import {
   Vector,
   makeData,
   vectorFromArray,
+  Dictionary,
   Float64,
+  Int32,
   LargeUtf8,
   LargeBinary,
+  Utf8,
 } from "apache-arrow";
 
 import { Dataset } from "../lib/datamodel";
 
-// Regression: Arrow LargeUtf8 / LargeBinary columns broke Dataset.fromArrow.
-// pandas/polars pyarrow-backed string columns serialize as `large_string`
-// (LargeUtf8, typeId 20) rather than `string` (Utf8, typeId 5); the dtype
-// mapper only special-cased Utf8, so a LargeUtf8 column produced an
-// unrecognised "largeutf8" dtype and threw
+// Regression: Arrow LargeUtf8 / LargeBinary / dictionary-string columns broke
+// Dataset.fromArrow. pandas/polars pyarrow-backed string columns serialize as
+// `large_string` (LargeUtf8, typeId 20) rather than `string` (Utf8, typeId 5),
+// and pandas `category` / polars Categorical|Enum columns serialize as
+// Dictionary<_, Utf8>. The dtype mapper only special-cased Utf8, so these
+// produced unrecognised dtypes and threw e.g.
 // `Unknown or unsupported data_type: largeutf8`. LargeBinary (typeId 19) had
 // the matching gap in the binary base64 branch.
 
+// LargeUtf8/LargeBinary use 64-bit offset buffers (BigInt64Array) that
+// vectorFromArray can't build in this apache-arrow version, so the vectors are
+// assembled manually from a packed data buffer + cumulative offsets.
 const enc = new TextEncoder();
 
 const largeUtf8Vector = (strings: string[]): Vector => {
@@ -65,7 +72,7 @@ const largeBinaryVector = (buffers: Uint8Array[]): Vector => {
 };
 
 describe("fromArrow with large Arrow types", () => {
-  test("decodes LargeUtf8 and LargeBinary columns", async () => {
+  test("decodes LargeUtf8, LargeBinary and dictionary-string columns", async () => {
     const table = new Table({
       name: largeUtf8Vector(["alpha", "beta", "gamma"]),
       blob: largeBinaryVector([
@@ -73,6 +80,11 @@ describe("fromArrow with large Arrow types", () => {
         Uint8Array.of(4, 5),
         Uint8Array.of(6),
       ]),
+      // pandas `category` / polars Categorical|Enum -> Dictionary<Int32, Utf8>.
+      color: vectorFromArray(
+        ["red", "green", "red"],
+        new Dictionary(new Utf8(), new Int32()),
+      ),
       value: vectorFromArray([1.5, 2.5, 3.5], new Float64()),
     });
 
@@ -82,10 +94,11 @@ describe("fromArrow with large Arrow types", () => {
     expect(rows).toHaveLength(3);
     // LargeUtf8 round-trips as plain strings.
     expect(rows.map((r) => r.name)).toEqual(["alpha", "beta", "gamma"]);
+    // Dictionary-encoded strings decode to plain strings.
+    expect(rows.map((r) => r.color)).toEqual(["red", "green", "red"]);
     // Numeric control column is unaffected.
     expect(rows.map((r) => r.value)).toEqual([1.5, 2.5, 3.5]);
     // LargeBinary is base64-encoded, exactly like Binary.
-    expect(rows[0].blob).toBe(Buffer.from([1, 2, 3]).toString("base64"));
     expect(rows.map((r) => r.blob)).toEqual([
       Buffer.from([1, 2, 3]).toString("base64"),
       Buffer.from([4, 5]).toString("base64"),


### PR DESCRIPTION
## Problem

`Dataset.fromArrow` throws on any datasource whose query result contains a text column:

```
getData error: Error: Unknown or unsupported data_type: largeutf8
  at e.fromArrow ... at e.query
```

## Root cause

`arrowTypeToDType` maps an Arrow column type to the internal (zarr) dtype. It special-cased **`Utf8`** (typeId 5) → `"v2:object"`, but let **`LargeUtf8`** (typeId **20**) fall through to the lowercased type name `"largeutf8"`, which the zarr dtype resolver rejects.

This started surfacing in production because **pandas/polars pyarrow-backed string columns serialize as Arrow `large_string` (`LargeUtf8`)** via `pyarrow.Table.from_pandas`, not `string` (`Utf8`). So once string columns came through Arrow-backed (a pandas/pyarrow default shift), every datasource with a text column broke.

`LargeBinary` (typeId 19) had the matching gap: `fromArrow`'s base64 branch only matched `isBinary` (typeId 4), so a `LargeBinary` column would skip the base64 encoding *and* hit the same unknown-dtype throw.

## Fix

- `arrowTypeToDType`: treat `LargeUtf8` like `Utf8` (object dtype). Switched the magic `typeId` checks to the named `DataType` predicates (`isUtf8`/`isLargeUtf8`/`isNull`) for clarity, consistent with `fromArrow` just below.
- `fromArrow`: route `LargeBinary` through the same base64 branch as `Binary`.

The column values themselves already decode correctly — `vector.toArray()` yields strings/bytes for the large variants — so only the dtype mapping (and the binary base64 routing) needed fixing.

## Test

`large-arrow-types.test.ts` builds an Arrow table with `LargeUtf8` + `LargeBinary` columns (plus a `Float64` control) and round-trips it through `fromArrow` → `asDataframe`, asserting strings come back as strings and binary as base64. Verified it **fails on `main`** with the exact `Unknown or unsupported data_type: largeutf8` error and **passes** with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
