### PR TITLE
fix(eidos): deliver spec on renderer init, real schema validation, retryable mounts (0.11.1)

### DIFF
--- a/packages/eidos/__tests__/eidosmodel.test.ts
+++ b/packages/eidos/__tests__/eidosmodel.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Regression tests for the schema loader behind validateSchema().
+ *
+ * The old loader returned `res.body` (a ReadableStream) to ajv's
+ * compileAsync, which silently compiled an accept-everything validator —
+ * and checked `res.statusCode`, which does not exist on fetch Responses,
+ * so HTTP errors were swallowed too.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const ROOT = "https://schemas.oceanum.io/eidos/root.json";
+const CHILD = "https://schemas.oceanum.io/eidos/node/test-child.json";
+
+const schemas: Record<string, object> = {
+  [ROOT]: {
+    $id: ROOT,
+    type: "object",
+    required: ["id", "name"],
+    properties: {
+      id: { type: "string" },
+      name: { type: "string" },
+      root: { $ref: CHILD },
+    },
+  },
+  [CHILD]: {
+    $id: CHILD,
+    type: "object",
+    required: ["nodeType"],
+    properties: { nodeType: { type: "string" } },
+  },
+};
+
+const goodFetch = vi.fn(async (uri: string) => ({
+  ok: true,
+  status: 200,
+  json: async () => schemas[uri],
+}));
+
+describe("validateSchema()", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("rejects when the schema fails to load (HTTP error)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: false, status: 404, json: async () => ({}) })),
+    );
+    const { validateSchema } = await import("../src/lib/eidosmodel");
+    await expect(validateSchema({ id: "x", name: "x" })).rejects.toThrow(
+      "Loading error: 404",
+    );
+  });
+
+  it("accepts a spec that satisfies the schema (resolving $refs via the loader)", async () => {
+    vi.stubGlobal("fetch", goodFetch);
+    const { validateSchema } = await import("../src/lib/eidosmodel");
+    await expect(
+      validateSchema({ id: "ok", name: "OK", root: { nodeType: "world" } }),
+    ).resolves.toBe(true);
+    // The $ref child schema must have been fetched through the loader.
+    expect(goodFetch).toHaveBeenCalledWith(CHILD);
+  });
+
+  it("rejects a spec that violates the schema — validation is not a no-op", async () => {
+    vi.stubGlobal("fetch", goodFetch);
+    const { validateSchema } = await import("../src/lib/eidosmodel");
+    await expect(
+      validateSchema({ id: 123, root: { nodeType: 42 } }),
+    ).rejects.toThrow(/EIDOS spec validation failed/);
+  });
+});

--- a/packages/eidos/__tests__/render.test.ts
+++ b/packages/eidos/__tests__/render.test.ts
@@ -26,6 +26,7 @@ vi.mock("../src/lib/eidosmodel", () => ({
 }));
 
 import { render } from "../src/lib/render";
+import { validateSchema } from "../src/lib/eidosmodel";
 
 const makeSpec = () => ({
   version: "0.11",
@@ -90,6 +91,27 @@ describe("render()", () => {
     iframe.dispatchEvent(new Event("error"));
 
     await expect(pending).rejects.toThrow("Failed to load EIDOS renderer");
+    expect(el.getAttribute("data-eidos-initialized")).toBeNull();
+    expect(el.querySelector("iframe")).toBeNull();
+
+    // A retry in the same container must not hit the already-mounted guard.
+    const retry = render(el, makeSpec());
+    const retryIframe = await waitForIframe(el);
+    retryIframe.dispatchEvent(new Event("load"));
+    const view = await retry;
+    expect(view.iframe).toBe(retryIframe);
+    view.destroy();
+  });
+
+  it("cleans up the container when spec validation fails, allowing retry", async () => {
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+
+    // e.g. a transient schema-fetch failure — must not poison the container.
+    vi.mocked(validateSchema).mockRejectedValueOnce(
+      new Error("Loading error: 503"),
+    );
+    await expect(render(el, makeSpec())).rejects.toThrow("Invalid Eidos Spec");
     expect(el.getAttribute("data-eidos-initialized")).toBeNull();
     expect(el.querySelector("iframe")).toBeNull();
 

--- a/packages/eidos/__tests__/render.test.ts
+++ b/packages/eidos/__tests__/render.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Regression tests for render() message handling and mount lifecycle.
+ *
+ * - The init-message handler must post a *snapshot* of the valtio proxy:
+ *   proxies are not structured-cloneable, so cloning/posting the proxy
+ *   itself threw DataCloneError on every renderer init and the spec never
+ *   reached the iframe.
+ * - A failed iframe load must clean up the container, otherwise the
+ *   data-eidos-initialized guard rejects every retry in that element.
+ */
+import { describe, expect, it, vi } from "vitest";
+import * as v8 from "node:v8";
+
+// Some DOM test environments do not expose structuredClone. Polyfill with
+// the v8 serializer, which has the same DataCloneError semantics for
+// proxies as the real structured clone algorithm.
+if (typeof globalThis.structuredClone !== "function") {
+  (globalThis as Record<string, unknown>).structuredClone = (value: unknown) =>
+    v8.deserialize(v8.serialize(value));
+}
+
+// render() schema-validates against the live schema URL before mounting —
+// stub it so tests stay offline.
+vi.mock("../src/lib/eidosmodel", () => ({
+  validateSchema: vi.fn().mockResolvedValue(true),
+}));
+
+import { render } from "../src/lib/render";
+
+const makeSpec = () => ({
+  version: "0.11",
+  id: "test-spec",
+  name: "Test Spec",
+  root: { id: "root", nodeType: "world" },
+});
+
+/** Wait until render() has appended its iframe to the container. */
+const waitForIframe = async (el: HTMLElement): Promise<HTMLIFrameElement> => {
+  for (let i = 0; i < 50; i++) {
+    const iframe = el.querySelector<HTMLIFrameElement>("iframe");
+    if (iframe) return iframe;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error("iframe was never created");
+};
+
+describe("render()", () => {
+  it("responds to the renderer init message with a cloneable spec snapshot", async () => {
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+
+    const pending = render(el, makeSpec());
+    const iframe = await waitForIframe(el);
+    iframe.dispatchEvent(new Event("load"));
+    const view = await pending;
+
+    const win = iframe.contentWindow;
+    expect(win).toBeTruthy();
+    const postMessage = vi.spyOn(win!, "postMessage");
+
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: { type: "init", id: "test-spec" },
+        source: win,
+      }),
+    );
+
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    const message = postMessage.mock.calls[0][0] as {
+      id: string;
+      type: string;
+      payload: Record<string, unknown>;
+    };
+    expect(message.type).toBe("spec");
+    expect(message.id).toBe("test-spec");
+    expect(message.payload.name).toBe("Test Spec");
+    // The payload must survive the structured clone that postMessage
+    // performs — the old code posted the raw valtio proxy, which throws.
+    expect(() => structuredClone(message.payload)).not.toThrow();
+
+    view.destroy();
+  });
+
+  it("cleans up the container when the iframe fails to load, allowing retry", async () => {
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+
+    const pending = render(el, makeSpec());
+    const iframe = await waitForIframe(el);
+    iframe.dispatchEvent(new Event("error"));
+
+    await expect(pending).rejects.toThrow("Failed to load EIDOS renderer");
+    expect(el.getAttribute("data-eidos-initialized")).toBeNull();
+    expect(el.querySelector("iframe")).toBeNull();
+
+    // A retry in the same container must not hit the already-mounted guard.
+    const retry = render(el, makeSpec());
+    const retryIframe = await waitForIframe(el);
+    retryIframe.dispatchEvent(new Event("load"));
+    const view = await retry;
+    expect(view.iframe).toBe(retryIframe);
+    view.destroy();
+  });
+});

--- a/packages/eidos/package.json
+++ b/packages/eidos/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oceanum/eidos",
   "private": false,
-  "version": "0.10.2",
+  "version": "0.11.1",
   "type": "module",
   "main": "./dist/index.js",
   "files": [
@@ -9,7 +9,8 @@
   ],
   "scripts": {
     "generate-types": "node ./scripts/generate-interfaces.js",
-    "build": "vite build"
+    "build": "vite build",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "ajv": "^8.17.1",

--- a/packages/eidos/src/lib/eidosmodel.ts
+++ b/packages/eidos/src/lib/eidosmodel.ts
@@ -5,9 +5,11 @@ let validator: ValidateFunction | null = null;
 
 const loadSchema = async (uri: string) => {
   const res = await fetch(uri);
-  if (res.statusCode >= 400)
-    throw new Error("Loading error: " + res.statusCode);
-  return res.body;
+  // fetch Responses expose `status`/`ok`, not `statusCode` — the old check
+  // never fired. Returning `res.body` (a ReadableStream) handed ajv a
+  // non-schema, silently compiling an accept-everything validator.
+  if (!res.ok) throw new Error("Loading error: " + res.status);
+  return res.json();
 };
 
 const validateSchema = async (spec: any): Promise<boolean> => {

--- a/packages/eidos/src/lib/render.ts
+++ b/packages/eidos/src/lib/render.ts
@@ -1,9 +1,9 @@
-import { proxy, subscribe, snapshot, Proxy } from 'valtio/vanilla';
-import { validateSchema } from './eidosmodel';
-import { EidosSpec } from '../schema/interfaces';
-import { version } from '../../package.json';
+import { proxy, subscribe, snapshot, Proxy } from "valtio/vanilla";
+import { validateSchema } from "./eidosmodel";
+import { EidosSpec } from "../schema/interfaces";
+import { version } from "../../package.json";
 
-const MINOR_VERSION = version.split('.').slice(0, 2).join('.');
+const MINOR_VERSION = version.split(".").slice(0, 2).join(".");
 const DEFAULT_RENDERER = `https://render.eidos.oceanum.io/v${MINOR_VERSION}/index.html`;
 
 /**
@@ -52,28 +52,37 @@ const render = async (
   spec: EidosSpec,
   options: RenderOptions = {},
 ): Promise<RenderResult> => {
-  const { id, eventListener, renderer = DEFAULT_RENDERER, authToken, onChange } = options;
+  const {
+    id,
+    eventListener,
+    renderer = DEFAULT_RENDERER,
+    authToken,
+    onChange,
+  } = options;
 
   // Check if this container is already initialized
   // We check both for an existing iframe and a marker on the container itself
   // This prevents double-mounting even if destroy() was called but the container is being reused
-  const existingIframe = element.querySelector('iframe[data-eidos-renderer]');
+  const existingIframe = element.querySelector("iframe[data-eidos-renderer]");
   const isInitialized =
-    element.getAttribute('data-eidos-initialized') === 'true';
+    element.getAttribute("data-eidos-initialized") === "true";
 
   if (existingIframe || isInitialized) {
     throw new Error(
-      'EIDOS renderer already mounted in this container. Call destroy() before re-rendering.',
+      "EIDOS renderer already mounted in this container. Call destroy() before re-rendering.",
     );
   }
 
   // Mark container as initialized
-  element.setAttribute('data-eidos-initialized', 'true');
+  element.setAttribute("data-eidos-initialized", "true");
 
   // Validate the spec before creating proxy
   try {
     await validateSchema(spec);
   } catch (e: any) {
+    // Clear the mount guard so a failed validation (e.g. a transient
+    // schema-fetch error) does not poison the container for retries.
+    element.removeAttribute("data-eidos-initialized");
     throw new Error(`Invalid Eidos Spec: ${e.message}`);
   }
 
@@ -82,13 +91,13 @@ const render = async (
   const _id = id || spec.id;
 
   return new Promise((resolve, reject) => {
-    const iframe = document.createElement('iframe');
+    const iframe = document.createElement("iframe");
     iframe.src = `${renderer}?id=${_id}`;
-    iframe.width = '100%';
-    iframe.height = '100%';
-    iframe.frameBorder = '0';
+    iframe.width = "100%";
+    iframe.height = "100%";
+    iframe.frameBorder = "0";
     // Mark this as an EIDOS iframe for duplicate detection
-    iframe.setAttribute('data-eidos-renderer', 'true');
+    iframe.setAttribute("data-eidos-renderer", "true");
     element.appendChild(iframe);
 
     let messageHandler: ((event: MessageEvent) => void) | null = null;
@@ -102,21 +111,25 @@ const render = async (
         token: string | (() => string | Promise<string>),
       ) => {
         const resolvedToken =
-          typeof token === 'function' ? await token() : token;
+          typeof token === "function" ? await token() : token;
         win?.postMessage(
           {
             id: _id,
-            type: 'auth',
+            type: "auth",
             payload: resolvedToken,
           },
-          '*',
+          "*",
         );
       };
 
       messageHandler = (event: MessageEvent) => {
         // Debug: log all messages from iframe
         if (event.source === win && event.data?.type) {
-          console.log('[EIDOS] Message from renderer:', event.data.type, event.data);
+          console.log(
+            "[EIDOS] Message from renderer:",
+            event.data.type,
+            event.data,
+          );
         }
 
         if (event.source !== win) return;
@@ -125,7 +138,7 @@ const render = async (
         // Some EIDOS renderers may not include ID in event messages
         if (event.data.id && event.data.id !== _id) return;
 
-        if (event.data.type === 'init') {
+        if (event.data.type === "init") {
           // Send initial spec. Snapshot first: the valtio proxy itself is
           // not structured-cloneable (postMessage/structuredClone throw
           // DataCloneError on any Proxy), so cloning `eidos` directly made
@@ -133,10 +146,10 @@ const render = async (
           win?.postMessage(
             {
               id: _id,
-              type: 'spec',
+              type: "spec",
               payload: snapshot(eidos),
             },
-            '*',
+            "*",
           );
           // Send auth token on init if provided
           if (authToken) {
@@ -147,7 +160,7 @@ const render = async (
           eventListener?.(event.data);
         }
       };
-      window.addEventListener('message', messageHandler);
+      window.addEventListener("message", messageHandler);
 
       // Subscribe to changes and send patches to renderer
       unsubscribe = subscribe(eidos, () => {
@@ -157,10 +170,10 @@ const render = async (
         win?.postMessage(
           {
             id: _id,
-            type: 'spec',
+            type: "spec",
             payload: currentSnapshot,
           },
-          '*',
+          "*",
         );
 
         // Notify parent of changes (for Yjs sync, etc.)
@@ -173,7 +186,7 @@ const render = async (
       }
 
       const triggerAction = (payload: unknown) => {
-        win?.postMessage({ id: _id, type: 'event', payload }, '*');
+        win?.postMessage({ id: _id, type: "event", payload }, "*");
       };
 
       resolve({
@@ -183,14 +196,14 @@ const render = async (
         iframe,
         destroy: () => {
           if (messageHandler) {
-            window.removeEventListener('message', messageHandler);
+            window.removeEventListener("message", messageHandler);
           }
           if (unsubscribe) {
             unsubscribe();
           }
           iframe.remove();
           // Clear the initialization marker when explicitly destroyed
-          element.removeAttribute('data-eidos-initialized');
+          element.removeAttribute("data-eidos-initialized");
         },
       });
     };
@@ -200,8 +213,8 @@ const render = async (
       // otherwise the data-eidos-initialized guard rejects every
       // subsequent render() in this element.
       iframe.remove();
-      element.removeAttribute('data-eidos-initialized');
-      reject(new Error('Failed to load EIDOS renderer'));
+      element.removeAttribute("data-eidos-initialized");
+      reject(new Error("Failed to load EIDOS renderer"));
     };
   });
 };

--- a/packages/eidos/src/lib/render.ts
+++ b/packages/eidos/src/lib/render.ts
@@ -126,12 +126,15 @@ const render = async (
         if (event.data.id && event.data.id !== _id) return;
 
         if (event.data.type === 'init') {
-          // Send initial spec
+          // Send initial spec. Snapshot first: the valtio proxy itself is
+          // not structured-cloneable (postMessage/structuredClone throw
+          // DataCloneError on any Proxy), so cloning `eidos` directly made
+          // this handler crash on every init and the spec never arrived.
           win?.postMessage(
             {
               id: _id,
               type: 'spec',
-              payload: structuredClone(eidos),
+              payload: snapshot(eidos),
             },
             '*',
           );
@@ -193,6 +196,11 @@ const render = async (
     };
 
     iframe.onerror = () => {
+      // Clean up the failed mount so the container can be retried —
+      // otherwise the data-eidos-initialized guard rejects every
+      // subsequent render() in this element.
+      iframe.remove();
+      element.removeAttribute('data-eidos-initialized');
       reject(new Error('Failed to load EIDOS renderer'));
     };
   });

--- a/packages/eidos/vite.config.ts
+++ b/packages/eidos/vite.config.ts
@@ -1,9 +1,14 @@
+/// <reference types="vitest/config" />
 import { NodeGlobalsPolyfillPlugin } from "@esbuild-plugins/node-globals-polyfill";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: "jsdom",
+    include: ["__tests__/**/*.test.ts"],
+  },
   define: {
     "process.env": {},
   },


### PR DESCRIPTION
## Why

Every `@oceanum/eidos` embed rendered a permanently blank iframe. Root-caused live in-browser while debugging the EIDOS website (eidosxr/website): two independent failures meant the spec never reached the hosted renderer.

## The four bugs

1. **Init handler crashed on every announcement** — it posted `structuredClone(eidos)`, the raw valtio proxy. Proxies are never structured-cloneable (`DataCloneError`), so the spec-send crashed each time the renderer announced `{type:'init'}`. Fixed to `snapshot(eidos)`, same as the subscribe path. Console signature of the bug: `[EIDOS] Message from renderer: init` followed by `DataCloneError: ... #<Object> could not be cloned`, ~1/s.
2. **Schema validation was a silent no-op** — the loader returned `res.body` (a `ReadableStream`) to ajv's `compileAsync`, which compiled an accept-everything validator; it also checked `res.statusCode`, which doesn't exist on fetch Responses, so HTTP errors were swallowed. Now parses JSON and checks `res.ok`.
3. **Failed loads poisoned the container** — `iframe.onerror` rejected without removing the iframe or clearing `data-eidos-initialized`, so every retry threw "already mounted". Now cleans up before rejecting.
4. **Stale dist at publish** — 0.11.0 shipped a dist built at 0.10.x (the version bump was made without rebuilding), so `DEFAULT_RENDERER` pointed at the **v0.10** runtime, which never announces init (the announce loop shipped in the v0.11 runtime). Added `prepublishOnly: npm run build` and bumped to **0.11.1**.

Bugs 1+4 compound: with the default renderer nothing ever asks for the spec; pointing at v0.11 made the ask arrive and crash instead.

## Verification

- `vitest run` in `packages/eidos`: **2 files, 5/5 tests green** (jsdom) — init payload is cloneable and correct, loader rejects HTTP errors, validation accepts/rejects correctly through $ref resolution, failed mounts clean up and retry.
- Built dist bakes `0.11.1` (→ renderer default `v0.11`), no `0.10.2` remnants; ESM import exposes the same `render`/`EidosProvider`/`useEidosSpec` surface.
- End-to-end contract was proven during the website debugging session: manually posting `{id, type:'spec', payload}` to the renderer iframe (exactly what the fixed handler now does) makes the map render.

## After merge

Publish 0.11.1, then remove the workaround in eidosxr/website `EmbedFrame.tsx` (renderer pin + manual spec delivery) — the embeds still rendering after its removal is the end-to-end acceptance test. Companion schema fix (inline-dataset `oneOf`) is in eidosxr/eidos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkzsGKtJmYWyBhBRuzKcnM