### PR TITLE
feat(datamesh)!: remove gateway API version sniffing, always use v1 sessions

### DIFF
--- a/packages/datamesh/proxy/guide.md
+++ b/packages/datamesh/proxy/guide.md
@@ -131,7 +131,7 @@ const connector = new Connector("proxy", {
 Notes:
 
 - The constructor requires a `token`. When using the proxy, the token you pass here is ignored by the upstream because the proxy overwrites the `x-DATAMESH-TOKEN` header with the secret.
-- The connector will probe `GET /session` on the `gateway` to detect the API version. Ensure your proxy forwards that path.
+- The connector acquires a session via `GET /session/?duration=...` on the `gateway` and sends `X-DATAMESH-SESSIONID` on subsequent requests. Ensure your proxy forwards the `/session/` path and that header.
 
 ## Security considerations
 

--- a/packages/datamesh/src/lib/connector.ts
+++ b/packages/datamesh/src/lib/connector.ts
@@ -26,6 +26,7 @@ export class Connector {
   private _nocache = false;
   private _sessionParams: Record<string, number> = {};
   private _currentSession: Session | null = null;
+  private _sessionPromise: Promise<Session> | null = null;
   service?: string;
   gateway?: string;
 
@@ -149,15 +150,28 @@ export class Connector {
   }
 
   /**
-   * Get the current session or create a new one if none exists.
+   * Get the current session, or create a new one if none exists or the
+   * current one has expired.
    *
    * @returns The current session.
    */
   async getSession(): Promise<Session> {
-    if (!this._currentSession) {
-      return this.createSession();
+    // Reuse the live session, but not one at/past its server-side expiry
+    // (60s margin for clock skew and in-flight requests).
+    if (
+      this._currentSession &&
+      this._currentSession.endTime.getTime() - 60_000 > Date.now()
+    ) {
+      return this._currentSession;
     }
-    return this._currentSession;
+    // Single-flight: concurrent callers share one acquisition instead of
+    // each opening (and orphaning) a server-side session.
+    if (!this._sessionPromise) {
+      this._sessionPromise = this.createSession().finally(() => {
+        this._sessionPromise = null;
+      });
+    }
+    return this._sessionPromise;
   }
 
   /**
@@ -169,7 +183,7 @@ export class Connector {
   private async getSessionHeaders(
     additionalHeaders: Record<string, string> = {},
   ): Promise<Record<string, string>> {
-    const session = this._currentSession ?? (await this.createSession());
+    const session = await this.getSession();
     return session.addHeader({
       ...this._authHeaders,
       ...additionalHeaders,
@@ -314,7 +328,7 @@ export class Connector {
     const url = `${this._gateway}/zarr/query/${stage.qhash}`;
     const params = query.parameters;
 
-    // Get headers with session information if available
+    // Acquire session headers (a session is always created)
     const headers = await this.getSessionHeaders();
 
     // Pass the headers to the Dataset.zarr method

--- a/packages/datamesh/src/lib/connector.ts
+++ b/packages/datamesh/src/lib/connector.ts
@@ -24,7 +24,6 @@ export class Connector {
   private _authHeaders: Record<string, string>;
   private _gateway: string;
   private _nocache = false;
-  private _isV1 = true;
   private _sessionParams: Record<string, number> = {};
   private _currentSession: Session | null = null;
   service?: string;
@@ -90,35 +89,6 @@ export class Connector {
       typeof options.sessionDuration === "number"
     ) {
       this._sessionParams = { duration: options.sessionDuration };
-    }
-
-    // Check if the API is v1 (supports sessions)
-    this._checkApiVersion();
-  }
-
-  /**
-   * Check if the API version supports sessions.
-   *
-   * @private
-   */
-  private async _checkApiVersion(): Promise<void> {
-    try {
-      // Simply check to see if we can get a session
-      const response = await fetch(`${this._gateway}/session`, {
-        headers: this._authHeaders,
-      });
-
-      if (response.status === 200) {
-        this._isV1 = true;
-        console.info("Using datamesh API version 1");
-      } else {
-        this._isV1 = false;
-        console.info("Using datamesh API version 0");
-      }
-    } catch {
-      // If we can't connect to the gateway, assume it's not a v1 API
-      this._isV1 = false;
-      console.info("Using datamesh API version 0");
     }
   }
 
@@ -191,7 +161,7 @@ export class Connector {
   }
 
   /**
-   * Get headers with session information if available.
+   * Get headers with session information, creating a session if none exists.
    *
    * @param additionalHeaders - Additional headers to include.
    * @returns Headers with session information.
@@ -199,18 +169,11 @@ export class Connector {
   private async getSessionHeaders(
     additionalHeaders: Record<string, string> = {},
   ): Promise<Record<string, string>> {
-    if (this._isV1 && !this._currentSession) {
-      await this.createSession();
-    }
-
-    if (this._currentSession) {
-      return this._currentSession.addHeader({
-        ...this._authHeaders,
-        ...additionalHeaders,
-      });
-    }
-
-    return { ...this._authHeaders, ...additionalHeaders };
+    const session = this._currentSession ?? (await this.createSession());
+    return session.addHeader({
+      ...this._authHeaders,
+      ...additionalHeaders,
+    });
   }
 
   /**
@@ -348,7 +311,7 @@ export class Connector {
       return dataset;
     }
 
-    const url = `${this._gateway}/zarr/${this._isV1 ? "query/" : ""}${stage.qhash}`;
+    const url = `${this._gateway}/zarr/query/${stage.qhash}`;
     const params = query.parameters;
 
     // Get headers with session information if available

--- a/packages/datamesh/src/lib/session.ts
+++ b/packages/datamesh/src/lib/session.ts
@@ -32,30 +32,6 @@ export class Session {
     connection: any,
     options: { duration?: number } = {},
   ): Promise<Session> {
-    // Check if the connection supports sessions (v1 API)
-    if (!connection._isV1) {
-      const session = new Session();
-      session.id = "dummy_session";
-      session.user = "dummy_user";
-      session.creationTime = new Date();
-      session.endTime = new Date(
-        Date.now() + (options.duration || 3600) * 1000,
-      );
-      session.write = false;
-      session.verified = false;
-      session._connection = connection;
-
-      // Register cleanup function for when the process exits
-      if (typeof process !== "undefined" && typeof process.on === "function") {
-        session._beforeExitHandler = () => {
-          void session.close();
-        };
-        process.once("beforeExit", session._beforeExitHandler);
-      }
-
-      return session;
-    }
-
     try {
       const headers = { ...connection._authHeaders };
       headers["Cache-Control"] = "no-store";
@@ -128,11 +104,6 @@ export class Session {
    * @throws {Error} - If the session cannot be closed and finaliseWrite is true.
    */
   async close(finaliseWrite = false): Promise<void> {
-    // Back-compatibility with beta version (ignoring)
-    if (!this._connection._isV1) {
-      return;
-    }
-
     if (this._closed) {
       return;
     }

--- a/packages/datamesh/src/test/getdataobject.test.ts
+++ b/packages/datamesh/src/test/getdataobject.test.ts
@@ -39,14 +39,14 @@ function stubFetch(
   return calls;
 }
 
-async function makeConnector(): Promise<Connector> {
+function makeConnector(): Connector {
   return new Connector("test-token", { gateway: "https://gw.test" });
 }
 
 describe("Connector.getDataObject", () => {
   it("downloads staged data with the requested format and returns bytes", async () => {
     const calls = stubFetch({ body: new Uint8Array([1, 2, 3, 4]) });
-    const c = await makeConnector();
+    const c = makeConnector();
 
     const buf = await c.getDataObject("QHASH", "nc");
 
@@ -56,7 +56,7 @@ describe("Connector.getDataObject", () => {
 
   it("url-encodes the format param", async () => {
     const calls = stubFetch();
-    const c = await makeConnector();
+    const c = makeConnector();
     await c.getDataObject("Q", "application/x-netcdf");
     expect(calls).toContain(
       "https://gw.test/oceanql/Q?f=application%2Fx-netcdf",
@@ -65,14 +65,14 @@ describe("Connector.getDataObject", () => {
 
   it("returns an empty ArrayBuffer for an empty 200 response", async () => {
     stubFetch({ body: new Uint8Array([]) });
-    const c = await makeConnector();
+    const c = makeConnector();
     const buf = await c.getDataObject("QHASH", "nc");
     expect(buf.byteLength).toBe(0);
   });
 
   it("throws on a server error", async () => {
     stubFetch({ status: 500, body: JSON.stringify({ detail: "boom" }) });
-    const c = await makeConnector();
+    const c = makeConnector();
     await expect(c.getDataObject("QHASH", "nc")).rejects.toThrow("boom");
   });
 });

--- a/packages/datamesh/src/test/getdataobject.test.ts
+++ b/packages/datamesh/src/test/getdataobject.test.ts
@@ -5,7 +5,7 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-// Mock fetch: /session → 404 (treat as API v0, no session handshake), and the
+// Mock fetch: session acquisition returns a stub session, and the
 // staged-data endpoint returns the given bytes/status.
 function stubFetch(
   staged: { status?: number; body?: Uint8Array | string } = {},
@@ -16,7 +16,18 @@ function stubFetch(
     vi.fn(async (url: string) => {
       const u = String(url);
       calls.push(u);
-      if (u.includes("/session")) return new Response("", { status: 404 });
+      if (u.includes("/session/?")) {
+        return new Response(
+          JSON.stringify({
+            id: "sess-abc",
+            user: "u",
+            creation_time: new Date().toISOString(),
+            end_time: new Date(Date.now() + 3600e3).toISOString(),
+            write: false,
+          }),
+          { status: 200 },
+        );
+      }
       if (u.includes("/oceanql/")) {
         return new Response(staged.body ?? new Uint8Array([1, 2, 3, 4]), {
           status: staged.status ?? 200,
@@ -28,14 +39,8 @@ function stubFetch(
   return calls;
 }
 
-// The constructor kicks off an async _checkApiVersion() that hits /session.
-// Our stub answers 404, so the connector settles to API v0 (no session
-// handshake). Construct, then let that fetch resolve before exercising
-// getDataObject, otherwise the default _isV1=true races us into createSession.
 async function makeConnector(): Promise<Connector> {
-  const c = new Connector("test-token", { gateway: "https://gw.test" });
-  await new Promise((r) => setTimeout(r, 0));
-  return c;
+  return new Connector("test-token", { gateway: "https://gw.test" });
 }
 
 describe("Connector.getDataObject", () => {

--- a/packages/datamesh/src/test/session-zarr.test.ts
+++ b/packages/datamesh/src/test/session-zarr.test.ts
@@ -1,0 +1,101 @@
+import { test, expect, vi, beforeEach, afterEach } from "vitest";
+import { Connector } from "../lib/connector";
+import { Dataset } from "../lib/datamodel";
+import { CachedHTTPStore } from "../lib/zarr";
+
+// Helper: mock fetch for the session-acquire and stage endpoints.
+const mockConnectorFetch = () =>
+  vi.fn(async (url: string) => {
+    const u = String(url);
+    if (u.includes("/session/?")) {
+      return {
+        status: 200,
+        json: async () => ({
+          id: "sess-abc",
+          user: "u",
+          creation_time: new Date().toISOString(),
+          end_time: new Date(Date.now() + 3600e3).toISOString(),
+          write: false,
+        }),
+      } as unknown as Response;
+    }
+    if (u.includes("/oceanql/stage/")) {
+      return {
+        status: 200,
+        json: async () => ({
+          query: { datasource: "test" },
+          qhash: "hash123",
+          formats: ["zarr"],
+          size: 1,
+          dlen: 1,
+          coordmap: {},
+          coordkeys: {},
+          container: "dataset",
+          sig: "s",
+        }),
+      } as unknown as Response;
+    }
+    return {
+      status: 200,
+      text: async () => "",
+      json: async () => ({}),
+    } as unknown as Response;
+  });
+
+const zarrCall = () =>
+  (Dataset.zarr as unknown as { mock: { calls: unknown[][] } }).mock.calls[0];
+
+beforeEach(() => {
+  vi.spyOn(Dataset, "zarr").mockResolvedValue({
+    variables: {},
+    coordkeys: {},
+  } as never);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+test("a session is always created and passed to zarr requests", async () => {
+  vi.stubGlobal("fetch", mockConnectorFetch());
+  const connector = new Connector("tok", { service: "https://gw.example" });
+  await connector.query({ datasource: "test" });
+
+  const headers = zarrCall()?.[1] as Record<string, string> | undefined;
+  expect(headers?.["X-DATAMESH-SESSIONID"]).toBe("sess-abc");
+});
+
+test("the zarr view is always addressed via the query path", async () => {
+  vi.stubGlobal("fetch", mockConnectorFetch());
+  const connector = new Connector("tok", { service: "https://gw.example" });
+  await connector.query({ datasource: "test" });
+
+  expect(zarrCall()?.[0]).toBe("https://gw.example/zarr/query/hash123");
+});
+
+test("CachedHTTPStore forwards the session header on every chunk request", async () => {
+  const seen: Record<string, string>[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (_url: string, opts: RequestInit) => {
+      seen.push(opts.headers as Record<string, string>);
+      return {
+        status: 200,
+        arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer,
+      } as unknown as Response;
+    }),
+  );
+
+  const store = new CachedHTTPStore(
+    "https://gw.example/zarr/query/abc",
+    {
+      Authorization: "Token tok",
+      "X-DATAMESH-SESSIONID": "sess-abc",
+    },
+    { ttl: 0 },
+  );
+  await store.get("/temperature/0.0.0" as `/${string}`);
+
+  expect(seen[0]?.["X-DATAMESH-SESSIONID"]).toBe("sess-abc");
+});

--- a/packages/datamesh/src/test/session-zarr.test.ts
+++ b/packages/datamesh/src/test/session-zarr.test.ts
@@ -5,12 +5,26 @@ import { CachedHTTPStore } from "../lib/zarr";
 
 // Helper: mock fetch for the session-acquire and stage endpoints. Session ids
 // are handed out sequentially (sess-1, sess-2, ...) with the given lifetime.
-const mockConnectorFetch = (sessionLifetimeMs = 3600e3) => {
+// sessionDelayMs delays the session response so concurrent acquisitions
+// genuinely overlap; failFirstSession makes the first acquisition return 500.
+const mockConnectorFetch = (
+  sessionLifetimeMs = 3600e3,
+  { sessionDelayMs = 0, failFirstSession = false } = {},
+) => {
   let sessions = 0;
   return vi.fn(async (url: string) => {
     const u = String(url);
     if (u.includes("/session/?")) {
       sessions += 1;
+      if (sessionDelayMs > 0) {
+        await new Promise((r) => setTimeout(r, sessionDelayMs));
+      }
+      if (failFirstSession && sessions === 1) {
+        return {
+          status: 500,
+          text: async () => "boom",
+        } as unknown as Response;
+      }
       return {
         status: 200,
         json: async () => ({
@@ -83,17 +97,31 @@ describe("datamesh v1 sessions", () => {
   });
 
   it("single-flights session acquisition across concurrent requests", async () => {
-    const fetchMock = mockConnectorFetch();
+    // Delay the session response so the acquisitions genuinely overlap.
+    const fetchMock = mockConnectorFetch(3600e3, { sessionDelayMs: 20 });
     vi.stubGlobal("fetch", fetchMock);
     const connector = new Connector("tok", { service: "https://gw.example" });
 
-    await Promise.all([
-      connector.query({ datasource: "test" }),
-      connector.query({ datasource: "test" }),
+    const [a, b] = await Promise.all([
+      connector.getSession(),
       connector.getSession(),
     ]);
+    await connector.query({ datasource: "test" });
 
     expect(sessionFetches(fetchMock).length).toBe(1);
+    expect(b).toBe(a);
+  });
+
+  it("retries acquisition after a failed attempt instead of caching the rejection", async () => {
+    const fetchMock = mockConnectorFetch(3600e3, { failFirstSession: true });
+    vi.stubGlobal("fetch", fetchMock);
+    const connector = new Connector("tok", { service: "https://gw.example" });
+
+    await expect(connector.getSession()).rejects.toThrow();
+    const session = await connector.getSession();
+
+    expect(session.id).toBe("sess-2");
+    expect(sessionFetches(fetchMock).length).toBe(2);
   });
 
   it("acquires a fresh session when the current one has expired", async () => {

--- a/packages/datamesh/src/test/session-zarr.test.ts
+++ b/packages/datamesh/src/test/session-zarr.test.ts
@@ -1,20 +1,23 @@
-import { test, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Connector } from "../lib/connector";
 import { Dataset } from "../lib/datamodel";
 import { CachedHTTPStore } from "../lib/zarr";
 
-// Helper: mock fetch for the session-acquire and stage endpoints.
-const mockConnectorFetch = () =>
-  vi.fn(async (url: string) => {
+// Helper: mock fetch for the session-acquire and stage endpoints. Session ids
+// are handed out sequentially (sess-1, sess-2, ...) with the given lifetime.
+const mockConnectorFetch = (sessionLifetimeMs = 3600e3) => {
+  let sessions = 0;
+  return vi.fn(async (url: string) => {
     const u = String(url);
     if (u.includes("/session/?")) {
+      sessions += 1;
       return {
         status: 200,
         json: async () => ({
-          id: "sess-abc",
+          id: `sess-${sessions}`,
           user: "u",
           creation_time: new Date().toISOString(),
-          end_time: new Date(Date.now() + 3600e3).toISOString(),
+          end_time: new Date(Date.now() + sessionLifetimeMs).toISOString(),
           write: false,
         }),
       } as unknown as Response;
@@ -41,61 +44,96 @@ const mockConnectorFetch = () =>
       json: async () => ({}),
     } as unknown as Response;
   });
+};
 
-const zarrCall = () =>
-  (Dataset.zarr as unknown as { mock: { calls: unknown[][] } }).mock.calls[0];
+const zarrCalls = () =>
+  (Dataset.zarr as unknown as { mock: { calls: unknown[][] } }).mock.calls;
 
-beforeEach(() => {
-  vi.spyOn(Dataset, "zarr").mockResolvedValue({
-    variables: {},
-    coordkeys: {},
-  } as never);
-});
+const sessionFetches = (fetchMock: ReturnType<typeof mockConnectorFetch>) =>
+  fetchMock.mock.calls.filter(([u]) => String(u).includes("/session/?"));
 
-afterEach(() => {
-  vi.restoreAllMocks();
-  vi.unstubAllGlobals();
-});
+describe("datamesh v1 sessions", () => {
+  beforeEach(() => {
+    vi.spyOn(Dataset, "zarr").mockResolvedValue({
+      variables: {},
+      coordkeys: {},
+    } as never);
+  });
 
-test("a session is always created and passed to zarr requests", async () => {
-  vi.stubGlobal("fetch", mockConnectorFetch());
-  const connector = new Connector("tok", { service: "https://gw.example" });
-  await connector.query({ datasource: "test" });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
 
-  const headers = zarrCall()?.[1] as Record<string, string> | undefined;
-  expect(headers?.["X-DATAMESH-SESSIONID"]).toBe("sess-abc");
-});
+  it("always creates a session and passes it to zarr requests", async () => {
+    vi.stubGlobal("fetch", mockConnectorFetch());
+    const connector = new Connector("tok", { service: "https://gw.example" });
+    await connector.query({ datasource: "test" });
 
-test("the zarr view is always addressed via the query path", async () => {
-  vi.stubGlobal("fetch", mockConnectorFetch());
-  const connector = new Connector("tok", { service: "https://gw.example" });
-  await connector.query({ datasource: "test" });
+    const headers = zarrCalls()[0]?.[1] as Record<string, string> | undefined;
+    expect(headers?.["X-DATAMESH-SESSIONID"]).toBe("sess-1");
+  });
 
-  expect(zarrCall()?.[0]).toBe("https://gw.example/zarr/query/hash123");
-});
+  it("always addresses the zarr view via the query path", async () => {
+    vi.stubGlobal("fetch", mockConnectorFetch());
+    const connector = new Connector("tok", { service: "https://gw.example" });
+    await connector.query({ datasource: "test" });
 
-test("CachedHTTPStore forwards the session header on every chunk request", async () => {
-  const seen: Record<string, string>[] = [];
-  vi.stubGlobal(
-    "fetch",
-    vi.fn(async (_url: string, opts: RequestInit) => {
-      seen.push(opts.headers as Record<string, string>);
-      return {
-        status: 200,
-        arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer,
-      } as unknown as Response;
-    }),
-  );
+    expect(zarrCalls()[0]?.[0]).toBe("https://gw.example/zarr/query/hash123");
+  });
 
-  const store = new CachedHTTPStore(
-    "https://gw.example/zarr/query/abc",
-    {
-      Authorization: "Token tok",
-      "X-DATAMESH-SESSIONID": "sess-abc",
-    },
-    { ttl: 0 },
-  );
-  await store.get("/temperature/0.0.0" as `/${string}`);
+  it("single-flights session acquisition across concurrent requests", async () => {
+    const fetchMock = mockConnectorFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    const connector = new Connector("tok", { service: "https://gw.example" });
 
-  expect(seen[0]?.["X-DATAMESH-SESSIONID"]).toBe("sess-abc");
+    await Promise.all([
+      connector.query({ datasource: "test" }),
+      connector.query({ datasource: "test" }),
+      connector.getSession(),
+    ]);
+
+    expect(sessionFetches(fetchMock).length).toBe(1);
+  });
+
+  it("acquires a fresh session when the current one has expired", async () => {
+    // Lifetime below the 60s reuse margin, so the first session is already
+    // considered expired on next use.
+    const fetchMock = mockConnectorFetch(1000);
+    vi.stubGlobal("fetch", fetchMock);
+    const connector = new Connector("tok", { service: "https://gw.example" });
+
+    await connector.query({ datasource: "test" });
+    await connector.query({ datasource: "test" });
+
+    expect(sessionFetches(fetchMock).length).toBeGreaterThan(1);
+    const lastHeaders = zarrCalls().at(-1)?.[1] as Record<string, string>;
+    expect(lastHeaders["X-DATAMESH-SESSIONID"]).not.toBe("sess-1");
+  });
+
+  it("CachedHTTPStore forwards the session header on every chunk request", async () => {
+    const seen: Record<string, string>[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, opts: RequestInit) => {
+        seen.push(opts.headers as Record<string, string>);
+        return {
+          status: 200,
+          arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer,
+        } as unknown as Response;
+      }),
+    );
+
+    const store = new CachedHTTPStore(
+      "https://gw.example/zarr/query/abc",
+      {
+        Authorization: "Token tok",
+        "X-DATAMESH-SESSIONID": "sess-abc",
+      },
+      { ttl: 0 },
+    );
+    await store.get("/temperature/0.0.0" as `/${string}`);
+
+    expect(seen[0]?.["X-DATAMESH-SESSIONID"]).toBe("sess-abc");
+  });
 });


### PR DESCRIPTION
## Summary
- Removes the gateway API-version probe (`GET {gateway}/session`) and all `_isV1` branching from the datamesh client — the v0 API is deprecated and no longer deployed, so the client now always operates in v1 (session-aware) mode.
- Root cause this fixes: the probe was auth-gated and fired unawaited from the constructor, so any non-200 / CORS block / transient network error silently flipped the client to v0, stripping `X-DATAMESH-SESSIONID` from every request. Staging works session-less but the zarr query view does not, so gridded queries failed with `{"detail":"Session ID required"}` (observed in the EIDOS auv-demo GEBCO bathymetry layer).
- Changes: a session is always acquired before the first request (`getSessionHeaders`), the zarr view is always addressed via `/zarr/query/{qhash}`, and the v0 dummy-session branch in `Session.acquire` plus the v0 bypass in `Session.close` are removed.
- Tests: new `session-zarr.test.ts` (session always attached to zarr requests; v1 query path always used; `CachedHTTPStore` forwards the session header per chunk); `getdataobject.test.ts` updated to stub session acquisition instead of relying on the removed v0 escape hatch.

**BREAKING CHANGE:** legacy v0 (session-less) datamesh gateways are no longer supported.

## Test Plan
- [x] `vitest run` (datamesh package): 85 passed / 7 failed — all 7 failures are pre-existing integration tests hitting `https://gateway.datamesh.oceanum.io` which currently presents a self-signed certificate (verified identical failures on the unmodified tree)
- [x] `tsc --noEmit` clean; `vite build` clean
- [x] Live gateway check (datamesh.oceanum.io): gebco_2025 bbox query → session header present on first zarr request → 200, dataset loads with `lon, lat, elevation`
- [ ] Verify in the EIDOS dev harness (auv-demo spec) after rebuilding/reinstalling the `file:` dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)
