### PR TITLE
feat(datamesh): Connector.openZarr — session-attached lazy zarr open

### DIFF
--- a/packages/datamesh/src/lib/connector.ts
+++ b/packages/datamesh/src/lib/connector.ts
@@ -1,7 +1,7 @@
 import { Geometry } from "geojson";
 import { Datasource } from "./datasource";
 import { IQuery, Stage } from "./query";
-import { Dataset, HttpZarr, TempZarr } from "./datamodel";
+import { Dataset, HttpZarr, TempZarr, ZarrOptions } from "./datamodel";
 import { isDatameshDebugEnabled, measureTime } from "./observe";
 import { tableFromIPC, Table } from "apache-arrow";
 import { Session } from "./session";
@@ -349,6 +349,28 @@ export class Connector {
       }
     }
     return dataset;
+  }
+
+  /**
+   * Open a staged query's zarr store with the connector's session attached.
+   *
+   * Use this for lazy or schema-only access to a staged result — e.g. reading
+   * dimensions and variables from `.zmetadata` without downloading chunks. It
+   * attaches the same session + auth headers as {@link query}, so callers never
+   * hand-roll zarr auth headers: the gateway requires a v1 session on every
+   * `/zarr/query` request and returns `401 "Session ID required"` without it.
+   *
+   * @param url - Full zarr store URL, e.g. `${gateway}${stage.zarr_endpoint}`.
+   * @param options - Zarr open options (coordkeys, parameters, ttl, timeout, …).
+   * @returns A lazily-opened Dataset backed by the staged zarr store.
+   */
+  @measureTime
+  async openZarr(
+    url: string,
+    options: ZarrOptions = {},
+  ): Promise<Dataset<HttpZarr>> {
+    const headers = await this.getSessionHeaders();
+    return Dataset.zarr(url, headers, options);
   }
 
   /**

--- a/packages/datamesh/src/test/session-zarr.test.ts
+++ b/packages/datamesh/src/test/session-zarr.test.ts
@@ -164,4 +164,39 @@ describe("datamesh v1 sessions", () => {
 
     expect(seen[0]?.["X-DATAMESH-SESSIONID"]).toBe("sess-abc");
   });
+
+  it("openZarr attaches the session + auth headers to a directly-opened store", async () => {
+    vi.stubGlobal("fetch", mockConnectorFetch());
+    const connector = new Connector("tok", {
+      jwtAuth: "jwt-abc",
+      service: "https://gw.example",
+    });
+    await connector.openZarr("https://gw.example/zarr/query/hash123$", {
+      coordkeys: { x: "lon" },
+    });
+
+    const [url, headers, options] = (zarrCalls()[0] ?? []) as [
+      string,
+      Record<string, string>,
+      { coordkeys?: Record<string, string> },
+    ];
+    expect(url).toBe("https://gw.example/zarr/query/hash123$");
+    // The session header — its absence is the "Session ID required" 401.
+    expect(headers["X-DATAMESH-SESSIONID"]).toBe("sess-1");
+    expect(headers.Authorization).toBe("Bearer jwt-abc");
+    expect(options.coordkeys).toEqual({ x: "lon" });
+  });
+
+  it("openZarr sends the same session the query() zarr path sends (reused)", async () => {
+    vi.stubGlobal("fetch", mockConnectorFetch());
+    const connector = new Connector("tok", { service: "https://gw.example" });
+    await connector.query({ datasource: "test" });
+    await connector.openZarr("https://gw.example/zarr/query/hash123$");
+
+    const queryHeaders = zarrCalls()[0]?.[1] as Record<string, string>;
+    const openHeaders = zarrCalls()[1]?.[1] as Record<string, string>;
+    expect(openHeaders["X-DATAMESH-SESSIONID"]).toBe(
+      queryHeaders["X-DATAMESH-SESSIONID"],
+    );
+  });
 });


### PR DESCRIPTION
Adds a public **`Connector.openZarr(url, options)`** that opens a staged query's zarr store with the connector's **session + auth headers** attached (via the same `getSessionHeaders()` the `query()` zarr path uses).

## Why

The gateway now requires a **v1 session** (`X-DATAMESH-SESSIONID`) on every `/zarr/query` request and returns `401 {"detail":"Session ID required"}` without it. Consumers that opened a staged zarr endpoint **directly** — with only a bearer token, bypassing `connector.query()` — broke. The prime example is the EIDOS renderer's schema pre-load (`data-provider.tsx getSchema`), which hand-rolls `{ Authorization: Bearer … }` and calls `Dataset.zarr(url, headers)`; its `.zmetadata` fetches now 401 while the data path (which goes through `query()`) still works.

`openZarr` gives those callers a first-class, session-bearing lazy-open so they never hand-roll zarr auth headers again — and it removes the asymmetry where `getSessionHeaders` is `private` and only `query()` could attach a session.

## What

```ts
async openZarr(url: string, options: ZarrOptions = {}): Promise<Dataset<HttpZarr>> {
  const headers = await this.getSessionHeaders();
  return Dataset.zarr(url, headers, options);
}
```

Lazy by construction — `Dataset.zarr` only fetches `.zmetadata` on open; chunks load on read. Same `ZarrOptions` (coordkeys, parameters, ttl, timeout, …) as the rest of the zarr surface.

## Verification

- `npx vitest run src/test/session-zarr.test.ts` → **8/8 pass** (6 existing + 2 new):
  - `openZarr` attaches `X-DATAMESH-SESSIONID` + the auth header and forwards `options`
  - the session it sends matches the `query()` zarr path (reused, single session)
- `npx vite build` → clean; `openZarr` present in `dist/index.js` and typed in `dist/lib/connector.d.ts`.
- The 3 failing suites in the full run (`query`/`dataset`/`dataframe`) are **pre-existing live-gateway integration tests** (`new Connector(process.env.DATAMESH_TOKEN)` → `fetch failed` with no token/network); unrelated to this change.

## Downstream

The EIDOS renderer PR swaps its hand-rolled `getSchema` headers for `datameshGateway().openZarr(...)` — merge this first, then publish/rebuild `@oceanum/datamesh` so the renderer's `file:` dep picks up the method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)