### PR TITLE
fix(datamesh): read numpy fixed-width string columns without throwing

### DIFF
--- a/packages/datamesh/src/lib/datamodel.ts
+++ b/packages/datamesh/src/lib/datamodel.ts
@@ -257,6 +257,14 @@ const get_strides = (shape: readonly number[]) => {
   return stride;
 };
 
+/**
+ * True for zarrita's numpy fixed-width string dtypes: `v2:S<n>` (bytes, from
+ * `|S<n>`) and `v2:U<n>` (unicode, from `<U<n>`). Unlike `v2:object` these are
+ * not decoded to a plain array, so they need materialising before `unravel`.
+ */
+const isFixedWidthString = (dtype: DataType): boolean =>
+  /^v2:[SU]\d+$/.test(dtype as string);
+
 const unravel = <T extends DataType>(
   data: TypedArray<T> | Scalar[],
   shape: number[],
@@ -514,7 +522,11 @@ export class DataVar<
     );
     if (this.arr.dtype == "v2:object" || !_data.shape) {
       return unravel(_data.data, _data.shape, _data.stride) as Data;
-    } else if (this.arr.dtype == "bool") {
+    } else if (this.arr.dtype == "bool" || isFixedWidthString(this.arr.dtype)) {
+      // Both are backed by a lazy array-like view rather than a TypedArray:
+      // bool by a BoolArray, and numpy fixed-width strings (`|S<n>` -> `v2:S<n>`,
+      // `<U<n>` -> `v2:U<n>`) by a Byte/UnicodeStringArray. They are iterable but
+      // have no `.slice`, which `unravel` needs — so materialise them first.
       return unravel([..._data.data], _data.shape, _data.stride) as Data;
     } else {
       const attrs = this.arr.attrs as Record<string, unknown>;

--- a/packages/datamesh/src/test/fixed-width-strings.test.ts
+++ b/packages/datamesh/src/test/fixed-width-strings.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from "vitest";
 import * as zarr from "zarrita";
 import { DataVar } from "../lib/datamodel";
-import type { DataType, HttpZarr } from "../lib/datamodel";
+import type { HttpZarr } from "../lib/datamodel";
+// `DataType` is zarrita's; datamodel.ts imports it but does not re-export it.
+import type { DataType } from "zarrita";
 
 // Regression: numpy fixed-width string columns (`|S<n>` bytes, `<U<n>` unicode)
 // open as zarrita dtypes `v2:S<n>` / `v2:U<n>` — NOT `v2:object`. Their chunk

--- a/packages/datamesh/src/test/fixed-width-strings.test.ts
+++ b/packages/datamesh/src/test/fixed-width-strings.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import * as zarr from "zarrita";
+import { DataVar } from "../lib/datamodel";
+import type { DataType, HttpZarr } from "../lib/datamodel";
+
+// Regression: numpy fixed-width string columns (`|S<n>` bytes, `<U<n>` unicode)
+// open as zarrita dtypes `v2:S<n>` / `v2:U<n>` — NOT `v2:object`. Their chunk
+// data is a lazy Byte/UnicodeStringArray view: iterable, but with no `.slice`.
+// DataVar.get() used to route them down the numeric branch, where `unravel`
+// calls `data.slice(...)` and threw `TypeError: r.slice is not a function`.
+// This bit any query grouping by a string variable (e.g. an EIDOS worldlayer
+// with `timeSelect.groupby: "drone_id"`).
+
+const enc = (o: unknown) => new TextEncoder().encode(JSON.stringify(o));
+
+/** Open an in-memory zarr v2 array with the given dtype and raw chunk bytes. */
+const openArray = async (
+  dtype: string,
+  chunk: Uint8Array,
+  shape: number[] = [3],
+) => {
+  const store = new Map<string, Uint8Array>();
+  store.set("/.zgroup", enc({ zarr_format: 2 }));
+  store.set(
+    "/v/.zarray",
+    enc({
+      zarr_format: 2,
+      shape,
+      chunks: shape,
+      dtype,
+      compressor: null,
+      fill_value: null,
+      order: "C",
+      filters: null,
+      dimension_separator: ".",
+    }),
+  );
+  store.set(
+    "/v/.zattrs",
+    enc({ _ARRAY_DIMENSIONS: shape.map((_, i) => `d${i}`) }),
+  );
+  store.set(`/v/${shape.map(() => 0).join(".")}`, chunk);
+  return await zarr.open(zarr.root(store).resolve("/v"), { kind: "array" });
+};
+
+const dataVar = (arr: Awaited<ReturnType<typeof openArray>>, dims: string[]) =>
+  new DataVar<DataType, HttpZarr>(
+    "v",
+    dims,
+    {},
+    arr as unknown as zarr.Array<DataType, zarr.AsyncReadable>,
+  );
+
+/** ASCII bytes for `|S<width>`. */
+const bytesFor = (words: string[], width: number) => {
+  const out = new Uint8Array(words.length * width);
+  words.forEach((w, i) =>
+    new TextEncoder().encodeInto(w, out.subarray(i * width, (i + 1) * width)),
+  );
+  return out;
+};
+
+/** UTF-32LE code points for `<U<width>`. */
+const utf32For = (words: string[], width: number) => {
+  const out = new Uint8Array(words.length * width * 4);
+  const dv = new DataView(out.buffer);
+  words.forEach((w, i) =>
+    [...w].forEach((ch, j) =>
+      dv.setUint32((i * width + j) * 4, ch.codePointAt(0) as number, true),
+    ),
+  );
+  return out;
+};
+
+describe("DataVar.get() with numpy fixed-width string dtypes", () => {
+  it("reads a |S<n> (bytes) column as strings", async () => {
+    const arr = await openArray("|S4", bytesFor(["auv1", "auv2", "auv3"], 4));
+    expect(arr.dtype).toBe("v2:S4");
+    const out = await dataVar(arr, ["d0"]).get();
+    expect(Array.from(out as ArrayLike<string>)).toEqual([
+      "auv1",
+      "auv2",
+      "auv3",
+    ]);
+  });
+
+  it("reads a <U<n> (unicode) column as strings", async () => {
+    const arr = await openArray("<U3", utf32For(["abc", "def", "ghi"], 3));
+    expect(arr.dtype).toBe("v2:U3");
+    const out = await dataVar(arr, ["d0"]).get();
+    expect(Array.from(out as ArrayLike<string>)).toEqual(["abc", "def", "ghi"]);
+  });
+
+  it("preserves shape for a 2-D fixed-width string array", async () => {
+    const arr = await openArray(
+      "|S2",
+      bytesFor(["aa", "bb", "cc", "dd"], 2),
+      [2, 2],
+    );
+    const out = await dataVar(arr, ["d0", "d1"]).get();
+    expect(out).toEqual([
+      ["aa", "bb"],
+      ["cc", "dd"],
+    ]);
+  });
+
+  it("still reads numeric columns (the pre-existing branch) unchanged", async () => {
+    const buf = new Uint8Array(24);
+    new DataView(buf.buffer).setFloat64(0, 1.5, true);
+    new DataView(buf.buffer).setFloat64(8, 2.5, true);
+    new DataView(buf.buffer).setFloat64(16, 3.5, true);
+    const arr = await openArray("<f8", buf);
+    expect(arr.dtype).toBe("float64");
+    const out = await dataVar(arr, ["d0"]).get();
+    expect(Array.from(out as ArrayLike<number>)).toEqual([1.5, 2.5, 3.5]);
+  });
+});


### PR DESCRIPTION
Reading a numpy fixed-width string column threw:

```
TypeError: r.slice is not a function
    at unravel
    at DataVar.get
    at async DataWrapper.query
```

## Root cause

`DataVar.get()` (`datamodel.ts`) special-cases only two dtypes:

```ts
if (dtype == "v2:object" || !_data.shape) return unravel(_data.data, …);      // plain array
else if (dtype == "bool")                 return unravel([..._data.data], …); // BoolArray view
else                                      return unravel(normalizedData, …);  // TypedArray
```

numpy fixed-width strings — `|S<n>` (bytes) and `<U<n>` (unicode) — open in zarrita as **`v2:S<n>` / `v2:U<n>`**, *not* `v2:object`. So they fell through to the numeric branch, where `unravel` does `data.slice(offset, offset + shape[0])`. But their chunk data is a lazy `ByteStringArray`/`UnicodeStringArray` view — array-like and **iterable, with no `.slice`**.

Verified against zarrita directly:

```
dtype <i8   -> arr.dtype=int64      chunk.data=[object BigInt64Array]     hasSlice=true
dtype <f8   -> arr.dtype=float64    chunk.data=[object Float64Array]      hasSlice=true
dtype |O    -> arr.dtype=v2:object                                        (first branch, fine)
dtype |S8   -> arr.dtype=v2:S8      chunk.data=[object ByteStringArray]   hasSlice=false  ← throws
dtype <U8   -> arr.dtype=v2:U8      chunk.data=[object UnicodeStringArray] hasSlice=false ← throws
```

Every read of such a column threw. It surfaced in EIDOS as a worldlayer with `timeSelect.groupby: "drone_id"` — the groupby is the one place a string variable is `.get()`-ed (`data.variables[qt.groupby].get()`), while `lon`/`lat`/`time` are numeric and take the same branch harmlessly.

## Fix

Materialise the view before `unravel`, exactly as the existing `bool` branch already does for its `BoolArray`:

```ts
} else if (this.arr.dtype == "bool" || isFixedWidthString(this.arr.dtype)) {
  return unravel([..._data.data], _data.shape, _data.stride) as Data;
}
```

with `isFixedWidthString = (d) => /^v2:[SU]\d+$/.test(d)`. Spreading decodes correctly — `[...data]` on `|S4` yields `["auv1","auv2","auv3"]`, on `<U3` yields `["abc","def","ghi"]`. zarrita's `coerce_dtype` strips the endian marker before building the dtype string, so big-endian `>S8`/`>U8` normalise to `v2:S8`/`v2:U8` and are covered too.

`zarr.get()` always returns C-contiguous output whose `stride === get_strides(shape)`, so spread-iteration order matches `unravel`'s offset reconstruction — including strided sub-selections. Same semantics as the pre-existing `bool` branch.

## Verification

- New `src/test/fixed-width-strings.test.ts` (4 tests): `|S<n>` and `<U<n>` reads return decoded strings; 2-D shape preserved; numeric branch unchanged.
- **Non-vacuous**: reverting just `|| isFixedWidthString(...)` makes the three string tests fail with the exact reported `TypeError: data.slice is not a function`, while the numeric control still passes.
- Full unit suite green (incl. this one). `tsc --noEmit -p tsconfig.lib.json` → exit 0; `tsc --noEmit -p tsconfig.spec.json` (the config that includes tests) → clean. `vite build` clean. Prettier clean.
- The failures in a full `vitest run` (`query`/`dataset`/`dataframe`) are **pre-existing**: 6 are live-gateway integration tests (`new Connector(process.env.DATAMESH_TOKEN)` → no token/network here) and 1 is an unrelated assertion in `dataset.test.ts > dataset fromGeojson`. All reproduce identically on untouched `origin/main`; only `datamodel.ts` differs in this diff.

Independently fresh-eyes reviewed (verdict: approve; one Major found and fixed — see comment).

Unrelated to #14; branches off it on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)