### PR TITLE
release(datamesh): 0.10.0 — publish openZarr + fixed-width string fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13999,7 +13999,7 @@
     },
     "packages/datamesh": {
       "name": "@oceanum/datamesh",
-      "version": "0.8.2",
+      "version": "0.10.0",
       "dependencies": {
         "@msgpack/msgpack": "^3.1.2",
         "@types/geojson": "^7946.0.16",
@@ -14037,7 +14037,7 @@
     },
     "packages/eidos": {
       "name": "@oceanum/eidos",
-      "version": "0.9.6",
+      "version": "0.11.1",
       "dependencies": {
         "ajv": "^8.17.1",
         "valtio": "^2.3.0"
@@ -14055,7 +14055,7 @@
       "version": "9.3.0",
       "dependencies": {
         "@oceanum/datamesh": "^0.8.1",
-        "@oceanum/deck-gl-grid": "^9.3.1"
+        "@oceanum/deck-gl-grid": "~9.3.1"
       },
       "devDependencies": {
         "@deck.gl/core": "~9.3.0",
@@ -14069,6 +14069,47 @@
         "@deck.gl/geo-layers": "~9.3.0",
         "@deck.gl/layers": "~9.3.0",
         "@luma.gl/core": "~9.3.2"
+      }
+    },
+    "packages/layers/node_modules/@oceanum/datamesh": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@oceanum/datamesh/-/datamesh-0.8.4.tgz",
+      "integrity": "sha512-sDyQUyExxVO75F6oWMEi6StAJjg7rwR5vHYluPdsKBQuAn2gibYDu1W+nISjXJ0sragBWoN+ZhaFOfcEi9L8mg==",
+      "dependencies": {
+        "@msgpack/msgpack": "^3.1.2",
+        "@types/geojson": "^7946.0.16",
+        "@types/object-hash": "^3.0.6",
+        "apache-arrow": "^19.0.1",
+        "buffer": "^6.0.3",
+        "dayjs": "^1.11.13",
+        "idb-keyval": "^6.2.1",
+        "object-hash": "^3.0.0",
+        "wkx-ts": "^1.0.1",
+        "zarrita": "^0.4.0-next.23"
+      }
+    },
+    "packages/layers/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     }
   }

--- a/packages/datamesh/package.json
+++ b/packages/datamesh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oceanum/datamesh",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "scripts": {
     "build": "vite build",
     "build:docs": "typedoc"


### PR DESCRIPTION
Cuts `@oceanum/datamesh` **0.10.0**.

npm's latest is **0.9.1** (published 2026-06-30), which predates two fixes that have been sitting on `main` unpublished:

| PR | fix |
|---|---|
| #14 | `Connector.openZarr` — session-attached lazy zarr open. Without it, opening zarr against the gateway returns `{"detail":"Session ID required"}` on `.zmetadata` for geofilter/gridded (zarr-transported) sources. |
| #15 | read numpy fixed-width string columns (`v2:S<n>` / `v2:U<n>`) without throwing `r.slice is not a function`. |

The eidos platform frontend needs both and cannot depend on an unpublished local path (`file:../../github/oceanum-js/packages/datamesh` dangles on any CI runner).

`package-lock.json` is bumped in the same commit — the root lock records the workspace version, so bumping `package.json` alone desyncs `npm ci` (`EUSAGE`).

## Verification

- `npm run build -w packages/datamesh` → exit 0
- `dist/index.js` contains `openZarr` and the `v2:[SU]` fixed-width branch
- `dist/lib/connector.d.ts:139` declares `openZarr(url, options?): Promise<Dataset<HttpZarr>>`; `index.d.ts` re-exports it — so TS consumers see it
- 94 unit tests pass, including the fixed-width-strings suite

The 7 failing tests are live-gateway integration tests (`dataframe`, `dataset zarr`, …) that cannot run from this sandbox — `TypeError: fetch failed / DEPTH_ZERO_SELF_SIGNED_CERT` on outbound TLS. A version bump cannot affect them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yCkwdtEWMUDSFLtoCsDDw