### PR TITLE
fix(datamesh): renew idle-expired oceanql sessions on 401 and retry (zarr)

### DIFF
--- a/packages/datamesh/src/lib/connector.ts
+++ b/packages/datamesh/src/lib/connector.ts
@@ -175,6 +175,25 @@ export class Connector {
   }
 
   /**
+   * Session headers plus a renewal callback for LONG-LIVED zarr stores
+   * (query()/openZarr()): the store outlives the session, and the gateway can
+   * expire the session server-side after inactivity, so the store needs a way
+   * to swap in a fresh session and retry.
+   */
+  private async renewableSessionHeaders(): Promise<{
+    headers: Record<string, string>;
+    renewHeaders: () => Promise<Record<string, string>>;
+  }> {
+    let session = await this.getSession();
+    const headers = session.addHeader({ ...this._authHeaders });
+    const renewHeaders = async (): Promise<Record<string, string>> => {
+      session = await this.renewSession(session);
+      return session.addHeader({ ...this._authHeaders });
+    };
+    return { headers, renewHeaders };
+  }
+
+  /**
    * Replace a session the gateway has rejected (401): oceanql sessions can be
    * terminated server-side after inactivity, BEFORE their declared end time,
    * so the endTime check in getSession() is not sufficient. Drops the cached
@@ -346,14 +365,17 @@ export class Connector {
     const url = `${this._gateway}/zarr/query/${stage.qhash}`;
     const params = query.parameters;
 
-    // Acquire session headers (a session is always created)
-    const headers = await this.getSessionHeaders();
+    // Acquire session headers (a session is always created), with a renewal
+    // path: the returned Dataset is long-lived and its lazy chunk reads must
+    // survive server-side session expiry after inactivity.
+    const { headers, renewHeaders } = await this.renewableSessionHeaders();
 
     // Pass the headers to the Dataset.zarr method
     const dataset = await Dataset.zarr(url, headers, {
       parameters: params,
       timeout: options.timeout || 60000, // Default timeout value
       nocache: this._nocache,
+      renewHeaders,
     });
 
     if (query.variables) {
@@ -387,16 +409,7 @@ export class Connector {
     url: string,
     options: ZarrOptions = {},
   ): Promise<Dataset<HttpZarr>> {
-    let session = await this.getSession();
-    const headers = session.addHeader({ ...this._authHeaders });
-    // The zarr store outlives the session: after inactivity the gateway
-    // expires the session server-side and every request for the staged query
-    // 401s. Give the store a renewal path — swap in a fresh session and let
-    // it retry (single-flight on both sides).
-    const renewHeaders = async (): Promise<Record<string, string>> => {
-      session = await this.renewSession(session);
-      return session.addHeader({ ...this._authHeaders });
-    };
+    const { headers, renewHeaders } = await this.renewableSessionHeaders();
     return Dataset.zarr(url, headers, { renewHeaders, ...options });
   }
 

--- a/packages/datamesh/src/lib/connector.ts
+++ b/packages/datamesh/src/lib/connector.ts
@@ -175,6 +175,24 @@ export class Connector {
   }
 
   /**
+   * Replace a session the gateway has rejected (401): oceanql sessions can be
+   * terminated server-side after inactivity, BEFORE their declared end time,
+   * so the endTime check in getSession() is not sufficient. Drops the cached
+   * session only if it is still the stale one (a concurrent caller may already
+   * have replaced it) and acquires a fresh session — concurrent renewals share
+   * one acquisition via getSession()'s single-flight.
+   *
+   * @param stale - The session that was rejected.
+   * @returns A fresh session.
+   */
+  async renewSession(stale?: Session): Promise<Session> {
+    if (!stale || this._currentSession?.id === stale.id) {
+      this._currentSession = null;
+    }
+    return this.getSession();
+  }
+
+  /**
    * Get headers with session information, creating a session if none exists.
    *
    * @param additionalHeaders - Additional headers to include.
@@ -369,8 +387,17 @@ export class Connector {
     url: string,
     options: ZarrOptions = {},
   ): Promise<Dataset<HttpZarr>> {
-    const headers = await this.getSessionHeaders();
-    return Dataset.zarr(url, headers, options);
+    let session = await this.getSession();
+    const headers = session.addHeader({ ...this._authHeaders });
+    // The zarr store outlives the session: after inactivity the gateway
+    // expires the session server-side and every request for the staged query
+    // 401s. Give the store a renewal path — swap in a fresh session and let
+    // it retry (single-flight on both sides).
+    const renewHeaders = async (): Promise<Record<string, string>> => {
+      session = await this.renewSession(session);
+      return session.addHeader({ ...this._authHeaders });
+    };
+    return Dataset.zarr(url, headers, { renewHeaders, ...options });
   }
 
   /**

--- a/packages/datamesh/src/lib/datamodel.ts
+++ b/packages/datamesh/src/lib/datamodel.ts
@@ -563,6 +563,12 @@ export class DataVar<
  * Implements the DatasetApi interface.
  */
 export interface ZarrOptions {
+  /**
+   * Renew session headers after a gateway 401 (idle-expired oceanql session);
+   * the failed zarr request is retried once with the fresh headers. Wired
+   * automatically by Connector.openZarr.
+   */
+  renewHeaders?: () => Promise<Record<string, string>>;
   parameters?: Record<string, string | number>;
   chunks?: string;
   downsample?: Record<string, number>;
@@ -646,6 +652,7 @@ export class Dataset<S extends HttpZarr | TempZarr> {
       timeout: options.timeout,
       nocache: options.nocache,
       ttl: options.ttl,
+      renewHeaders: options.renewHeaders,
     }) as AsyncReadable;
 
     // Use tryWithConsolidated to gracefully handle stores without consolidated metadata

--- a/packages/datamesh/src/lib/zarr.ts
+++ b/packages/datamesh/src/lib/zarr.ts
@@ -62,6 +62,13 @@ interface CachedHTTPStoreOptions {
    */
   ttl?: number;
   timeout?: number;
+  /**
+   * Called when the gateway rejects a request with 401 (an oceanql session can
+   * be terminated server-side after inactivity, before its declared expiry).
+   * Must return fresh auth/session headers; the failed request is retried once
+   * with them. Renewal is single-flight across concurrent chunk fetches.
+   */
+  renewHeaders?: () => Promise<Record<string, string>>;
 }
 
 // Special key suffix for tracking cache creation time
@@ -77,6 +84,8 @@ export class CachedHTTPStore implements AsyncReadable {
   ttl: number | undefined;
   _pending: Record<string, boolean> = {};
   _cacheValid: boolean | undefined;
+  private _renewHeaders?: () => Promise<Record<string, string>>;
+  private _renewPromise: Promise<void> | null = null;
 
   constructor(
     root: string,
@@ -134,6 +143,30 @@ export class CachedHTTPStore implements AsyncReadable {
     });
     this.timeout = options.timeout || 60000;
     this.ttl = options.ttl;
+    this._renewHeaders = options.renewHeaders;
+  }
+
+  /**
+   * Renew the session headers after a 401, single-flight: concurrent chunk
+   * fetches that all hit the expired session share one renewal. The renewed
+   * headers are merged over fetchOptions.headers so store-added headers
+   * (x-parameters, x-chunks, x-filtered, …) are preserved.
+   */
+  private async renewSessionHeaders(): Promise<void> {
+    if (!this._renewHeaders) throw new Error("no renewHeaders callback");
+    if (!this._renewPromise) {
+      this._renewPromise = this._renewHeaders()
+        .then((renewed) => {
+          this.fetchOptions.headers = {
+            ...(this.fetchOptions.headers || {}),
+            ...renewed,
+          };
+        })
+        .finally(() => {
+          this._renewPromise = null;
+        });
+    }
+    return this._renewPromise;
   }
 
   /**
@@ -239,10 +272,37 @@ export class CachedHTTPStore implements AsyncReadable {
           signal: AbortSignal.timeout(this.timeout),
         };
         const query = new URLSearchParams(this.params).toString();
-        const response = await fetch(
+        let response = await fetch(
           `${this.url}${item}?${query}`,
           requestOptions,
         );
+
+        // An oceanql session can expire server-side after inactivity, before
+        // its declared end time — every request for the staged query then
+        // returns 401. Renew the session once and retry with fresh headers; a
+        // second 401 is a genuine auth failure and falls through to the error
+        // path below.
+        if (response.status === 401 && this._renewHeaders) {
+          await this.renewSessionHeaders();
+          response = await fetch(`${this.url}${item}?${query}`, {
+            ...requestOptions,
+            headers: {
+              ...(this.fetchOptions.headers || {}),
+              ...(options?.headers || {}),
+            },
+            signal: AbortSignal.timeout(this.timeout),
+          });
+          if (response.status === 401) {
+            // A freshly-renewed session was rejected too: genuine auth
+            // failure. Fail fast with the store's terminal semantics instead
+            // of falling into the generic retry loop below, which would
+            // hammer the gateway (and renew again) every 200ms until timeout.
+            console.error(
+              `Zarr request unauthorized after session renewal: ${this.url}${item}`,
+            );
+            return undefined;
+          }
+        }
 
         if (response.status === 404) {
           // Item is not found

--- a/packages/datamesh/src/lib/zarr.ts
+++ b/packages/datamesh/src/lib/zarr.ts
@@ -295,8 +295,9 @@ export class CachedHTTPStore implements AsyncReadable {
           if (response.status === 401) {
             // A freshly-renewed session was rejected too: genuine auth
             // failure. Fail fast with the store's terminal semantics instead
-            // of falling into the generic retry loop below, which would
-            // hammer the gateway (and renew again) every 200ms until timeout.
+            // of falling into the generic catch-all retry below, which would
+            // pointlessly re-fetch (and re-renew) for its 2-3 bounded
+            // attempts with misleading retry logging.
             console.error(
               `Zarr request unauthorized after session renewal: ${this.url}${item}`,
             );

--- a/packages/datamesh/src/test/session-renewal.test.ts
+++ b/packages/datamesh/src/test/session-renewal.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { CachedHTTPStore } from "../lib/zarr";
+import { Connector } from "../lib/connector";
+
+// Regression: an oceanql session can be terminated server-side after a period
+// of inactivity, BEFORE its declared end time. Every subsequent request for
+// the staged query then returns 401. The zarr store used to freeze the
+// session header at construction and treat 401 as a plain HTTP error; it now
+// renews the session (single-flight) and retries the request once.
+
+const enc = (o: unknown) => new TextEncoder().encode(JSON.stringify(o));
+
+describe("CachedHTTPStore 401 renewal", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  const makeStore = (renewHeaders?: () => Promise<Record<string, string>>) =>
+    new CachedHTTPStore(
+      "https://gateway.test/zarr/query/abc",
+      { "X-DATAMESH-SESSIONID": "stale-session", Authorization: "Token t" },
+      { parameters: { x: 1 }, renewHeaders },
+    );
+
+  it("renews once and retries with fresh headers on 401", async () => {
+    const calls: Array<Record<string, string>> = [];
+    const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+      calls.push({ ...(init.headers as Record<string, string>) });
+      if (calls.length === 1) return new Response("expired", { status: 401 });
+      return new Response(new Uint8Array([1, 2, 3]), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const renew = vi.fn(async () => ({
+      "X-DATAMESH-SESSIONID": "fresh-session",
+    }));
+    const store = makeStore(renew);
+    const data = await store.get("/.zmetadata");
+
+    expect(Array.from(data!)).toEqual([1, 2, 3]);
+    expect(renew).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // retry carries the renewed session id...
+    expect(calls[1]["X-DATAMESH-SESSIONID"]).toBe("fresh-session");
+    // ...and preserves the store-added zarr headers
+    expect(calls[1]["x-parameters"]).toBe(JSON.stringify({ x: 1 }));
+    expect(calls[1]["x-filtered"]).toBe("True");
+  });
+
+  it("single-flights renewal across concurrent chunk fetches", async () => {
+    let renewCount = 0;
+    const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+      const h = init.headers as Record<string, string>;
+      if (h["X-DATAMESH-SESSIONID"] === "stale-session")
+        return new Response("expired", { status: 401 });
+      return new Response(new Uint8Array([9]), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const renew = vi.fn(async () => {
+      renewCount += 1;
+      await new Promise((r) => setTimeout(r, 20)); // widen the race window
+      return { "X-DATAMESH-SESSIONID": "fresh-session" };
+    });
+    const store = makeStore(renew);
+    const results = await Promise.all([
+      store.get("/a/0"),
+      store.get("/a/1"),
+      store.get("/a/2"),
+    ]);
+
+    for (const r of results) expect(Array.from(r!)).toEqual([9]);
+    expect(renewCount).toBe(1); // one renewal shared by all three 401s
+  });
+
+  it("a second 401 after renewal fails fast — no retry-loop hammering", async () => {
+    const fetchMock = vi.fn(async () => new Response("nope", { status: 401 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const renew = vi.fn(async () => ({
+      "X-DATAMESH-SESSIONID": "still-rejected",
+    }));
+    const store = makeStore(renew);
+    // terminal semantics of the store: unrecoverable failures resolve undefined
+    await expect(store.get("/.zmetadata")).resolves.toBeUndefined();
+    expect(renew).toHaveBeenCalledTimes(1); // exactly one renewal attempt
+    expect(fetchMock).toHaveBeenCalledTimes(2); // original + one retry, no loop
+  });
+
+  it("without a renewHeaders callback, 401 keeps its pre-existing behavior", async () => {
+    const fetchMock = vi.fn(
+      async () => new Response("expired", { status: 401 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    // small timeout keeps the pre-existing generic retry loop short
+    const store = new CachedHTTPStore(
+      "https://gateway.test/zarr/query/abc",
+      { "X-DATAMESH-SESSIONID": "stale-session" },
+      { timeout: 400 },
+    );
+    await expect(store.get("/.zmetadata")).resolves.toBeUndefined();
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(1); // legacy retry loop
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Connector-level: renewSession must replace a session the gateway killed
+// early (its declared endTime is still in the future), and openZarr must wire
+// the whole path together.
+// ---------------------------------------------------------------------------
+
+const sessionJson = (id: string) => ({
+  id,
+  user: "test",
+  creation_time: new Date().toISOString(),
+  // declared expiry FAR in the future — the point is server-side early death
+  end_time: new Date(Date.now() + 3600_000).toISOString(),
+  write: false,
+  verified: true,
+});
+
+const gatewayMock = () => {
+  let sessionCount = 0;
+  const zmetadataCalls: Array<Record<string, string>> = [];
+  const zmetadata = {
+    metadata: {
+      ".zgroup": { zarr_format: 2 },
+      "v/.zarray": {
+        zarr_format: 2,
+        shape: [1],
+        chunks: [1],
+        dtype: "<f8",
+        compressor: null,
+        fill_value: null,
+        order: "C",
+        filters: null,
+      },
+      "v/.zattrs": { _ARRAY_DIMENSIONS: ["d0"] },
+    },
+    zarr_consolidated_format: 1,
+  };
+  const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+    const u = String(url);
+    if (u.includes("/session/")) {
+      sessionCount += 1;
+      return new Response(JSON.stringify(sessionJson(`s-${sessionCount}`)), {
+        status: 200,
+      });
+    }
+    if (u.includes(".zmetadata")) {
+      const h = (init?.headers ?? {}) as Record<string, string>;
+      zmetadataCalls.push({ ...h });
+      // the FIRST session is treated as already expired server-side
+      if (h["X-DATAMESH-SESSIONID"] === "s-1")
+        return new Response("Session ID required", { status: 401 });
+      return new Response(enc(zmetadata), { status: 200 });
+    }
+    return new Response("not found", { status: 404 });
+  });
+  return { fetchMock, zmetadataCalls, getSessionCount: () => sessionCount };
+};
+
+describe("Connector session renewal", () => {
+  beforeEach(() => vi.unstubAllGlobals());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("renewSession replaces a session the gateway killed before its endTime", async () => {
+    const { fetchMock } = gatewayMock();
+    vi.stubGlobal("fetch", fetchMock);
+    const connector = new Connector("test-token", {
+      service: "https://gateway.test",
+    });
+    const first = await connector.getSession();
+    expect(first.id).toBe("s-1");
+    // endTime is an hour away — getSession alone would keep returning it
+    expect(await connector.getSession()).toBe(first);
+
+    const renewed = await connector.renewSession(first);
+    expect(renewed.id).toBe("s-2");
+    expect(await connector.getSession()).toBe(renewed);
+  });
+
+  it("renewSession with a superseded session does not clobber the current one", async () => {
+    const { fetchMock } = gatewayMock();
+    vi.stubGlobal("fetch", fetchMock);
+    const connector = new Connector("test-token", {
+      service: "https://gateway.test",
+    });
+    const first = await connector.getSession();
+    const second = await connector.renewSession(first);
+    // a straggler still holding `first` renews — must NOT discard `second`
+    const third = await connector.renewSession(first);
+    expect(third).toBe(second);
+  });
+
+  it("openZarr recovers end-to-end from an idle-expired session", async () => {
+    const { fetchMock, zmetadataCalls, getSessionCount } = gatewayMock();
+    vi.stubGlobal("fetch", fetchMock);
+    const connector = new Connector("test-token", {
+      service: "https://gateway.test",
+    });
+
+    const dataset = await connector.openZarr(
+      "https://gateway.test/zarr/query/abc",
+      { coordkeys: {} as never },
+    );
+
+    expect(dataset).toBeDefined();
+    // first .zmetadata attempt used the killed session, retry used the fresh one
+    expect(zmetadataCalls[0]["X-DATAMESH-SESSIONID"]).toBe("s-1");
+    expect(
+      zmetadataCalls[zmetadataCalls.length - 1]["X-DATAMESH-SESSIONID"],
+    ).toBe("s-2");
+    expect(getSessionCount()).toBe(2);
+  });
+});

--- a/packages/datamesh/src/test/session-renewal.test.ts
+++ b/packages/datamesh/src/test/session-renewal.test.ts
@@ -144,6 +144,18 @@ const gatewayMock = () => {
         status: 200,
       });
     }
+    if (u.includes("/oceanql/stage/")) {
+      return new Response(
+        JSON.stringify({
+          qhash: "abc",
+          size: 1e9, // >= LAZY_LOAD_SIZE -> zarr transport
+          container: "dataset",
+          coordkeys: {},
+          formats: ["zarr"],
+        }),
+        { status: 200 },
+      );
+    }
     if (u.includes(".zmetadata")) {
       const h = (init?.headers ?? {}) as Record<string, string>;
       zmetadataCalls.push({ ...h });
@@ -204,6 +216,25 @@ describe("Connector session renewal", () => {
 
     expect(dataset).toBeDefined();
     // first .zmetadata attempt used the killed session, retry used the fresh one
+    expect(zmetadataCalls[0]["X-DATAMESH-SESSIONID"]).toBe("s-1");
+    expect(
+      zmetadataCalls[zmetadataCalls.length - 1]["X-DATAMESH-SESSIONID"],
+    ).toBe("s-2");
+    expect(getSessionCount()).toBe(2);
+  });
+
+  it("query() datasets also recover from an idle-expired session", async () => {
+    const { fetchMock, zmetadataCalls, getSessionCount } = gatewayMock();
+    vi.stubGlobal("fetch", fetchMock);
+    const connector = new Connector("test-token", {
+      service: "https://gateway.test",
+    });
+
+    // stage -> zarr transport (size >= LAZY_LOAD_SIZE); the staged store's
+    // first .zmetadata request uses the killed session and must renew.
+    const dataset = await connector.query({ datasource: "test-ds" } as never);
+
+    expect(dataset).not.toBeNull();
     expect(zmetadataCalls[0]["X-DATAMESH-SESSIONID"]).toBe("s-1");
     expect(
       zmetadataCalls[zmetadataCalls.length - 1]["X-DATAMESH-SESSIONID"],


### PR DESCRIPTION
An oceanql session can be terminated server-side after inactivity, **before its declared end time** — every subsequent request for the staged query then 401s.

## Root cause (two layers)

1. **`CachedHTTPStore` freezes the session header at construction** (`zarr.ts`) and treats 401 as a plain HTTP error — whose catch-all then re-fetches the dead session for its ~2-3 bounded attempts before resolving `undefined` — with no renewal path anywhere.
2. **`Connector.getSession()` only replaces a session at/past its declared `endTime`** — an idle-killed session passes that check and keeps being reused.

## Fix

- `Connector.renewSession(stale)` — drops the cached session **only if it is still the stale one** (a concurrent caller may have already replaced it), then re-acquires through `getSession()`'s existing single-flight.
- `Connector.openZarr` wires a `renewHeaders` callback into the zarr store.
- `CachedHTTPStore`: on 401 → renew (**single-flight across concurrent chunk fetches**, which all hit the expired session together) → retry once with renewed headers merged over the store's zarr headers (`x-parameters`/`x-chunks`/`x-filtered` preserved). A **second** 401 after renewal is a genuine auth failure and fails fast instead of entering the generic retry loop.
- Direct `CachedHTTPStore` users without the callback: behavior unchanged.

## Verification

New `session-renewal.test.ts` — **7/7**, network-free:
- renew + retry-once with header preservation
- one renewal shared by 3 concurrent 401ing chunk fetches
- persistent 401 → exactly 1 renewal + 2 fetches, resolves undefined (fail-fast, no pointless re-fetch/re-renew rounds)
- legacy no-callback path unchanged
- connector: stale replaced even with `endTime` an hour away; a straggler renewing a superseded session does **not** clobber the current one
- end-to-end: `openZarr` against a mocked gateway — first `.zmetadata` 401s on the killed session, retry succeeds on the fresh one, exactly 2 sessions acquired

Full datamesh suite: **101 passed**; the 7 failures are the pre-existing live-gateway tests blocked by this sandbox's TLS interception — identical to the 0.10.0 release baseline.

**Review round 2:** `Connector.query()` — the primary data path — was initially left unwired (fresh-eyes blocker); both `query()` and `openZarr()` now share `renewableSessionHeaders()`, with a dedicated `query()` end-to-end recovery test (suite now 8/8).

## After merge

Needs a patch release (`@oceanum/datamesh` 0.10.1, OTP required). EIDOS platform consumes `^0.10.0` so it picks the fix up on its next lockfile refresh; the EIDOS renderer's long-lived worldlayer datasets are the motivating case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yCkwdtEWMUDSFLtoCsDDw